### PR TITLE
docker: Install bindgen-cli

### DIFF
--- a/docker/hos_builder/Dockerfile
+++ b/docker/hos_builder/Dockerfile
@@ -47,8 +47,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         --profile=minimal \
         --component rustfmt clippy cargo llvm-tools rustc-dev rustdocs
 
-# todo: delete registy
-RUN /home/${USERNAME}/.cargo/bin/cargo install cargo-chef taplo-cli cargo-deny --locked
+RUN /home/${USERNAME}/.cargo/bin/cargo install cargo-chef taplo-cli cargo-deny bindgen-cli --locked \
+    && rm -rf /home/${USERNAME}/.cargo/git /home/${USERNAME}/.cargo/registry
 
 FROM base_fetcher AS uv
 


### PR DESCRIPTION
`bindgen-cli` is needed by `aws-lc-rs`, which is a new dependency of servo.

Fixes https://github.com/servo/servo/issues/35231