### PR TITLE
monitor: add support for mountless Rust-based image builds

### DIFF
--- a/monitor/Cargo.lock
+++ b/monitor/Cargo.lock
@@ -226,6 +226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
+name = "bytesize"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
+
+[[package]]
 name = "cc"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +929,7 @@ dependencies = [
  "askama",
  "askama_rocket",
  "atomic-write-file",
+ "bytesize",
  "chrono",
  "cmd_lib",
  "crossbeam-channel",

--- a/monitor/Cargo.toml
+++ b/monitor/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 askama = { version = "0.12.1", features = ["with-rocket"] }
 askama_rocket = "0.12.0"
 atomic-write-file = { version = "0.2.2", features = ["unnamed-tmpfile"] }
+bytesize = "2.0.1"
 chrono = "0.4.39"
 cmd_lib = "1.9.5"
 crossbeam-channel = "0.5.13"

--- a/monitor/src/auth.rs
+++ b/monitor/src/auth.rs
@@ -34,7 +34,7 @@ impl<'req> FromRequest<'req> for ApiKeyGuard<'req> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RemoteAddr {
     client_ip: Option<IpAddr>,
     real_ip: Option<IpAddr>,

--- a/monitor/src/data.rs
+++ b/monitor/src/data.rs
@@ -6,7 +6,7 @@ use std::{
 use jane_eyre::eyre;
 use tracing::info;
 
-use crate::DOTENV;
+use crate::{profile::Profile, DOTENV, LIB_MONITOR_DIR};
 
 pub fn get_data_path<'p>(path: impl Into<Option<&'p Path>>) -> eyre::Result<PathBuf> {
     let data = if let Some(path) = &DOTENV.monitor_data_path {
@@ -45,6 +45,18 @@ pub fn get_profile_data_path<'p>(
         Some(path) => profile_data.join(path),
         None => profile_data,
     })
+}
+
+pub fn get_profile_configuration_path<'p>(
+    profile: &Profile,
+    path: impl Into<Option<&'p Path>>,
+) -> PathBuf {
+    let profile_data = Path::new(&*LIB_MONITOR_DIR).join(&profile.configuration_name);
+
+    match path.into() {
+        Some(path) => profile_data.join(path),
+        None => profile_data,
+    }
 }
 
 #[tracing::instrument]

--- a/monitor/src/data.rs
+++ b/monitor/src/data.rs
@@ -50,13 +50,16 @@ pub fn get_profile_data_path<'p>(
 pub fn get_profile_configuration_path<'p>(
     profile: &Profile,
     path: impl Into<Option<&'p Path>>,
-) -> PathBuf {
-    let profile_data = Path::new(&*LIB_MONITOR_DIR).join(&profile.configuration_name);
-
-    match path.into() {
+) -> eyre::Result<PathBuf> {
+    let profile_data = Path::new(&*LIB_MONITOR_DIR)
+        .join(&profile.configuration_name)
+        .canonicalize()?;
+    let result = match path.into() {
         Some(path) => profile_data.join(path),
         None => profile_data,
-    }
+    };
+
+    Ok(result)
 }
 
 #[tracing::instrument]

--- a/monitor/src/github.rs
+++ b/monitor/src/github.rs
@@ -4,6 +4,7 @@ use std::{
     time::Instant,
 };
 
+use cmd_lib::run_fun;
 use jane_eyre::eyre::{self, Context};
 use serde::{Deserialize, Serialize};
 use tracing::trace;
@@ -103,4 +104,15 @@ pub fn list_registered_runners_for_host() -> eyre::Result<Vec<ApiRunner>> {
         .filter(|runner| runner.name.ends_with(&suffix));
 
     Ok(result.collect())
+}
+
+pub fn register_runner(name: &str, label: &str, work_folder: &str) -> eyre::Result<String> {
+    let github_api_suffix = &DOTENV.github_api_suffix;
+    let github_api_scope = &DOTENV.github_api_scope;
+    let result = run_fun!(gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28"
+    "$github_api_scope/actions/runners/generate-jitconfig"
+    -f "name=$name@$github_api_suffix" -F "runner_group_id=1" -f "work_folder=$work_folder"
+    -f "labels[]=self-hosted" -f "labels[]=X64" -f "labels[]=$label")?;
+
+    Ok(result)
 }

--- a/monitor/src/image.rs
+++ b/monitor/src/image.rs
@@ -176,6 +176,7 @@ fn rebuild_with_build_image_script(
     info!(build_script_path = ?build_script_path, ?snapshot_name, "Starting image rebuild");
     let pipe = || |reader| log_output_as_info(reader);
     spawn_with_output!($build_script_path $snapshot_name 2>&1)?.wait_with_pipe(&mut pipe())?;
+    Profiles::write_base_image_snapshot(profile_key, snapshot_name)?;
 
     Ok(())
 }

--- a/monitor/src/image.rs
+++ b/monitor/src/image.rs
@@ -196,7 +196,7 @@ fn rebuild_with_rust(
     let profile_configuration_path = get_profile_configuration_path(&profile, None);
     let guest_xml_path = get_profile_configuration_path(&profile, Path::new("guest.xml"));
 
-    let base_images_path = Path::new("/var/lib/libvirt/images/base").join(base_vm_name);
+    let base_images_path = profile.base_images_path();
     info!(?base_images_path, "Creating libvirt images subdirectory");
     create_dir_all(&base_images_path)?;
 
@@ -206,8 +206,8 @@ fn rebuild_with_rust(
     info!(?config_iso_path, "Creating config image file");
     run_cmd!(genisoimage -V CIDATA -R -f -o $config_iso_path $profile_configuration_path/user-data $profile_configuration_path/meta-data)?;
 
-    let base_image_symlink_path = base_images_path.join(format!("root.img"));
-    let base_image_filename = format!("root.img@{snapshot_name}");
+    let base_image_symlink_path = base_images_path.join(format!("base.img"));
+    let base_image_filename = format!("base.img@{snapshot_name}");
     let base_image_path = base_images_path.join(&base_image_filename);
     info!(?base_image_path, "Creating base image file");
     let mut base_image_file = File::create_new(&base_image_path)?;

--- a/monitor/src/image.rs
+++ b/monitor/src/image.rs
@@ -193,8 +193,8 @@ fn rebuild_with_rust(
         run_cmd!(virsh undefine -- $base_vm_name)?;
     }
 
-    let profile_configuration_path = get_profile_configuration_path(&profile, None);
-    let guest_xml_path = get_profile_configuration_path(&profile, Path::new("guest.xml"));
+    let profile_configuration_path = get_profile_configuration_path(&profile, None)?;
+    let guest_xml_path = get_profile_configuration_path(&profile, Path::new("guest.xml"))?;
 
     let base_images_path = profile.base_images_path();
     info!(?base_images_path, "Creating libvirt images subdirectory");

--- a/monitor/src/image.rs
+++ b/monitor/src/image.rs
@@ -211,7 +211,7 @@ fn rebuild_with_rust(
     let base_image_path = base_images_path.join(&base_image_filename);
     info!(?base_image_path, "Creating base image file");
     let mut base_image_file = File::create_new(&base_image_path)?;
-    let base_image_size = 8; // GiB
+    let base_image_size = 20; // GiB
     for i in 0..base_image_size {
         info!("Writing base image file: {i}/{base_image_size} GiB");
         for _ in 0..1024 {
@@ -237,8 +237,8 @@ fn rebuild_with_rust(
     run_cmd!(virsh change-media -- $base_vm_name sda $config_iso_path)?;
     run_cmd!(virsh resume -- $base_vm_name)?;
 
-    info!("Waiting for guest to shut down (max 40 seconds)"); // normally ~19 seconds
-    if !run_cmd!(time virsh event --timeout 40 -- $base_vm_name lifecycle).is_ok() {
+    info!("Waiting for guest to shut down (max 90 seconds)"); // normally ~37 seconds
+    if !run_cmd!(time virsh event --timeout 90 -- $base_vm_name lifecycle).is_ok() {
         bail!("virsh event timed out!");
     }
 

--- a/monitor/src/image.rs
+++ b/monitor/src/image.rs
@@ -197,10 +197,7 @@ fn rebuild_with_rust(
     }
 
     let profile_configuration_path = get_profile_configuration_path(&profile, None)?;
-
-    let base_images_path = profile.base_images_path();
-    info!(?base_images_path, "Creating libvirt images subdirectory");
-    create_dir_all(&base_images_path)?;
+    let base_images_path = create_base_images_dir(&profile)?;
 
     let config_iso_symlink_path = base_images_path.join(format!("config.iso"));
     let config_iso_filename = format!("config.iso@{snapshot_name}");
@@ -230,6 +227,14 @@ fn rebuild_with_rust(
     atomic_symlink(config_iso_filename, config_iso_symlink_path)?;
     atomic_symlink(base_image_filename, base_image_symlink_path)?;
     Ok(())
+}
+
+pub(self) fn create_base_images_dir(profile: &Profile) -> eyre::Result<PathBuf> {
+    let base_images_path = profile.base_images_path();
+    info!(?base_images_path, "Creating libvirt images subdirectory");
+    create_dir_all(&base_images_path)?;
+
+    Ok(base_images_path)
 }
 
 pub(self) fn create_disk_image(

--- a/monitor/src/image/ubuntu2204_rust.rs
+++ b/monitor/src/image/ubuntu2204_rust.rs
@@ -1,0 +1,58 @@
+use std::fs::File;
+use std::path::Path;
+use std::time::Duration;
+
+use bytesize::ByteSize;
+use cmd_lib::run_cmd;
+use jane_eyre::eyre;
+use tracing::info;
+
+use crate::data::get_profile_configuration_path;
+use crate::profile::Profile;
+use crate::shell::atomic_symlink;
+use crate::IMAGE_DEPS_DIR;
+
+use super::create_disk_image;
+use super::define_libvirt_guest;
+use super::start_libvirt_guest;
+use super::wait_for_guest;
+use super::CdromImage;
+
+pub(super) fn rebuild(
+    base_images_path: impl AsRef<Path>,
+    profile: &Profile,
+    snapshot_name: &str,
+) -> eyre::Result<()> {
+    let base_images_path = base_images_path.as_ref();
+    let base_vm_name = &profile.base_vm_name;
+    let profile_configuration_path = get_profile_configuration_path(&profile, None)?;
+    let config_iso_symlink_path = base_images_path.join(format!("config.iso"));
+    let config_iso_filename = format!("config.iso@{snapshot_name}");
+    let config_iso_path = base_images_path.join(&config_iso_filename);
+    let config_iso_path = config_iso_path.to_str().expect("Unsupported path");
+    info!(config_iso_path, "Creating config image file");
+    run_cmd!(genisoimage -V CIDATA -R -f -o $config_iso_path $profile_configuration_path/user-data $profile_configuration_path/meta-data)?;
+
+    let base_image_symlink_path = base_images_path.join(format!("base.img"));
+    let os_image_path = IMAGE_DEPS_DIR
+        .join("ubuntu2204")
+        .join("jammy-server-cloudimg-amd64.raw");
+    let os_image = File::open(os_image_path)?;
+    let base_image_path =
+        create_disk_image(base_images_path, snapshot_name, ByteSize::gib(20), os_image)?;
+
+    let guest_xml_path = get_profile_configuration_path(&profile, Path::new("guest.xml"))?;
+    define_libvirt_guest(base_vm_name, guest_xml_path, &[&"-f", &base_image_path])?;
+    start_libvirt_guest(base_vm_name, &[CdromImage::new("sda", config_iso_path)])?;
+    wait_for_guest(base_vm_name, Duration::from_secs(90))?;
+
+    let base_image_filename = Path::new(
+        base_image_path
+            .file_name()
+            .expect("Guaranteed by make_disk_image"),
+    );
+    atomic_symlink(config_iso_filename, config_iso_symlink_path)?;
+    atomic_symlink(base_image_filename, base_image_symlink_path)?;
+
+    Ok(())
+}

--- a/monitor/src/main.rs
+++ b/monitor/src/main.rs
@@ -30,7 +30,7 @@ use dotenv::dotenv;
 use jane_eyre::eyre::{self, eyre, Context, OptionExt};
 use mktemp::Temp;
 use rocket::{
-    fs::NamedFile,
+    fs::{FileServer, NamedFile},
     get,
     http::ContentType,
     post,
@@ -362,6 +362,10 @@ async fn main() -> eyre::Result<()> {
                 github_jitconfig_route,
                 boot_script_route,
             ],
+        )
+        .mount(
+            "/image-deps/",
+            FileServer::new(&*IMAGE_DEPS_DIR, rocket::fs::Options::NormalizeDirs),
         )
         .launch()
     };

--- a/monitor/src/main.rs
+++ b/monitor/src/main.rs
@@ -618,7 +618,12 @@ fn monitor_thread() -> eyre::Result<()> {
                     runners.update_ipv4_addresses();
                     profiles.update_ipv4_addresses();
 
-                    let result = profiles.boot_script(remote_addr);
+                    let result = runners
+                        .boot_script(remote_addr.clone())
+                        .transpose()
+                        .or_else(|| profiles.boot_script(remote_addr).transpose())
+                        .transpose()
+                        .and_then(|result| result.ok_or_eyre("No guest found with IP address"));
                     response_tx
                         .send(result)
                         .expect("Failed to send Response to API thread");

--- a/monitor/src/profile.rs
+++ b/monitor/src/profile.rs
@@ -40,7 +40,7 @@ pub struct Profile {
     pub image_type: ImageType,
 }
 
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub enum ImageType {
     #[default]
     BuildImageScript,
@@ -121,7 +121,9 @@ impl Profiles {
                 let base_vm_name = &profile.base_vm_name;
                 let libvirt_prefix = &DOTENV.libvirt_prefix;
                 create_dir(get_runner_data_path(id, None)?)?;
-                File::create_new(get_runner_data_path(id, Path::new("created-time"))?)?;
+                let mut runner_toml =
+                    File::create_new(get_runner_data_path(id, Path::new("runner.toml"))?)?;
+                writeln!(runner_toml, r#"image_type = "Rust""#)?;
                 run_cmd!(virt-clone --auto-clone --reflink -o $base_vm_name -n $libvirt_prefix-$base_vm_name.$id)?;
                 run_cmd!(virsh start -- $libvirt_prefix-$base_vm_name.$id)?;
                 Ok(())

--- a/monitor/src/profile.rs
+++ b/monitor/src/profile.rs
@@ -132,7 +132,15 @@ impl Profiles {
                 )?;
                 let vm_name = format!("{base_vm_name}.{id}");
                 let prefixed_vm_name = format!("{}-{vm_name}", DOTENV.libvirt_prefix);
-                register_runner(&vm_name, &profile.github_runner_label, "../a")?;
+                if !DOTENV.dont_register_runners {
+                    let mut github_api_registration = File::create_new(get_runner_data_path(
+                        id,
+                        Path::new("github-api-registration"),
+                    )?)?;
+                    github_api_registration.write_all(
+                        register_runner(&vm_name, &profile.github_runner_label, "../a")?.as_bytes(),
+                    )?;
+                }
                 let pipe = || |reader| log_output_as_info(reader);
                 spawn_with_output!(virt-clone --auto-clone --reflink -o $base_vm_name -n $prefixed_vm_name 2>&1)?.wait_with_pipe(&mut pipe())?;
                 // FIXME: This dance is only needed because `virt-clone -f` ignores cdrom drives.

--- a/monitor/src/runner.rs
+++ b/monitor/src/runner.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::{Debug, Display},
     fs::{self, File},
+    io::Read,
     net::Ipv4Addr,
     path::Path,
     process::Command,
@@ -11,7 +12,7 @@ use std::{
 use itertools::Itertools;
 use jane_eyre::eyre::{self, bail};
 use mktemp::Temp;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tracing::{error, info, trace, warn};
 
 use crate::{
@@ -19,6 +20,7 @@ use crate::{
     data::get_runner_data_path,
     github::{ApiGenerateJitconfigResponse, ApiRunner},
     libvirt::{get_ipv4_address, libvirt_prefix, take_screenshot, update_screenshot},
+    profile::ImageType,
     LIB_MONITOR_DIR,
 };
 
@@ -37,6 +39,12 @@ pub struct Runner {
     volume_name: Option<String>,
     ipv4_address: Option<Ipv4Addr>,
     github_jitconfig: Option<String>,
+    details: RunnerDetails,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct RunnerDetails {
+    image_type: ImageType,
 }
 
 #[derive(Debug, PartialEq)]
@@ -250,8 +258,11 @@ impl Runner {
     ///
     /// For use by [`Runners::new`] only. Does not create a runner.
     fn new(id: usize) -> eyre::Result<Self> {
-        let created_time = get_runner_data_path(id, Path::new("created-time"))?;
-        let created_time = fs::metadata(created_time)?.modified()?;
+        let created_time_path = get_runner_data_path(id, Path::new("created-time"))?;
+        let runner_toml_path = get_runner_data_path(id, Path::new("runner.toml"))?;
+        let created_time = fs::metadata(created_time_path)
+            .or_else(|_| fs::metadata(&runner_toml_path))?
+            .modified()?;
         trace!(?created_time, "[{id}]");
 
         let github_jitconfig = || -> eyre::Result<String> {
@@ -268,6 +279,14 @@ impl Runner {
             }
         };
 
+        let details = if let Ok(mut runner_toml) = File::open(&runner_toml_path) {
+            let mut contents = String::default();
+            runner_toml.read_to_string(&mut contents)?;
+            toml::from_str(&contents)?
+        } else {
+            RunnerDetails::default()
+        };
+
         Ok(Self {
             id,
             created_time,
@@ -276,6 +295,7 @@ impl Runner {
             volume_name: None,
             ipv4_address: None,
             github_jitconfig: github_jitconfig,
+            details,
         })
     }
 
@@ -334,7 +354,7 @@ impl Runner {
     }
 
     pub fn status(&self) -> Status {
-        if self.guest_name.is_none() || self.volume_name.is_none() {
+        if self.guest_name.is_none() || (self.needs_zfs_volume() && self.volume_name.is_none()) {
             return Status::Invalid;
         };
         let Some(registration) = &self.registration else {
@@ -350,6 +370,13 @@ impl Runner {
             return Status::Idle;
         }
         return Status::StartedOrCrashed;
+    }
+
+    fn needs_zfs_volume(&self) -> bool {
+        match self.details.image_type {
+            ImageType::BuildImageScript => true,
+            ImageType::Rust => false,
+        }
     }
 
     pub fn base_vm_name(&self) -> &str {

--- a/monitor/src/runner.rs
+++ b/monitor/src/runner.rs
@@ -251,6 +251,21 @@ impl Runners {
             }
         }
     }
+
+    pub fn boot_script(&self, remote_addr: RemoteAddr) -> eyre::Result<Option<String>> {
+        for (&id, runner) in self.runners.iter() {
+            if let Some(ipv4_address) = runner.ipv4_address {
+                if remote_addr == ipv4_address {
+                    let path = get_runner_data_path(id, Path::new("boot-script.sh"))?;
+                    let mut result = String::default();
+                    File::open(path)?.read_to_string(&mut result)?;
+                    return Ok(Some(result));
+                }
+            }
+        }
+
+        Ok(None)
+    }
 }
 
 impl Runner {

--- a/monitor/src/settings.rs
+++ b/monitor/src/settings.rs
@@ -16,7 +16,7 @@ pub struct Dotenv {
     // GITHUB_TOKEN not used
     // LIBVIRT_DEFAULT_URI not used
     pub monitor_api_token_authorization_value: String,
-    // SERVO_CI_GITHUB_API_SCOPE not used
+    pub github_api_scope: String,
     pub github_api_suffix: String,
     pub libvirt_prefix: String,
     pub zfs_prefix: String,
@@ -52,6 +52,7 @@ impl Dotenv {
 
         Self {
             monitor_api_token_authorization_value: format!("Bearer {monitor_api_token}"),
+            github_api_scope: env_string("SERVO_CI_GITHUB_API_SCOPE"),
             github_api_suffix: env_string("SERVO_CI_GITHUB_API_SUFFIX"),
             libvirt_prefix: env_string("SERVO_CI_LIBVIRT_PREFIX"),
             zfs_prefix: env_string("SERVO_CI_ZFS_PREFIX"),

--- a/server/nixos/monitor.nix
+++ b/server/nixos/monitor.nix
@@ -6,11 +6,16 @@
   lib,
   stdenv,
   makeWrapper,
+
+  cdrkit,
   gawk,
+  gh,
   git,
   gnused,
   libvirt,
   openssh,
+  time,
+  virt-manager,
   zfs,
   zsh,
 }: let
@@ -22,6 +27,7 @@
       ../../shared
       ../../macos13
       ../../ubuntu2204
+      ../../ubuntu2204-rust
       ../../ubuntu2204-wpt
       ../../windows10
       ../../common.sh
@@ -56,11 +62,15 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     monitorCrate
-    gawk
+    cdrkit  # for genisoimage(1)
+    gawk  # for awk(1)
+    gh
     git
-    gnused
-    libvirt
-    openssh
+    gnused  # for sed(1)
+    libvirt  # for virsh(1)
+    openssh  # for ssh(1)
+    time  # for time(1)
+    virt-manager  # for virt-clone(1)
     zfs
     zsh
     # TODO: list other commands needed by scripts here
@@ -78,6 +88,7 @@ in stdenv.mkDerivation rec {
     cp -R shared $out/lib/monitor
     cp -R macos13 $out/lib/monitor
     cp -R ubuntu2204 $out/lib/monitor
+    cp -R ubuntu2204-rust $out/lib/monitor
     cp -R ubuntu2204-wpt $out/lib/monitor
     cp -R windows10 $out/lib/monitor
     cp -R common.sh $out/lib/monitor

--- a/ubuntu2204-rust/boot-script.sh
+++ b/ubuntu2204-rust/boot-script.sh
@@ -3,10 +3,38 @@ set -eux
 
 actions_runner_version=2.323.0
 
-download() (
-    set -x
+download() {
     curl -fsSLO "http://192.168.100.1:8000/image-deps/ubuntu2204/$1"
-)
+}
+
+apt_install() {
+    # Install distro packages, but only if one or more are not already installed.
+    # Update the package lists first, to avoid failures when rebaking old images.
+    if ! dpkg -s "$@" > /dev/null 2>&1; then
+        apt update
+        # DEBIAN_FRONTEND needed to avoid hang when installing tshark
+        DEBIAN_FRONTEND=noninteractive apt install -y "$@"
+    fi
+}
+
+install_github_actions_runner() {
+    actions_runner_version=2.323.0
+
+    apt_install jq  # Used by start_github_actions_runner()
+
+    if ! [ -e actions-runner-linux-x64-$actions_runner_version.tar.gz ]; then
+        download actions-runner-linux-x64-$actions_runner_version.tar.gz
+        rm -Rf actions-runner
+        mkdir -p actions-runner
+        ( cd actions-runner; tar xf ../actions-runner-linux-x64-$actions_runner_version.tar.gz )
+    fi
+}
+
+start_github_actions_runner() {
+    export RUNNER_ALLOW_RUNASROOT=1
+    curl -fsS --max-time 5 --retry 99 --retry-all-errors http://192.168.100.1:8000/github-jitconfig | jq -er . > jitconfig
+    actions-runner/run.sh --jitconfig $(cat jitconfig)
+}
 
 mkdir -p /ci
 cd /ci
@@ -14,30 +42,14 @@ cd /ci
 if ! [ -e image-expanded ]; then
     touch image-expanded
     reboot
-fi
-
-set -- jq  # Used further below
-
-# Install distro packages, but only if one or more are not already installed.
-# Update the package lists first, to avoid failures when rebaking old images.
-if ! dpkg -s "$@" > /dev/null 2>&1; then
-    apt update
-    # DEBIAN_FRONTEND needed to avoid hang when installing tshark
-    DEBIAN_FRONTEND=noninteractive apt install -y "$@"
-fi
-
-if ! [ -e actions-runner-linux-x64-$actions_runner_version.tar.gz ]; then
-    download actions-runner-linux-x64-$actions_runner_version.tar.gz
-    rm -Rf actions-runner
-    mkdir -p actions-runner
-    ( cd actions-runner; tar xf ../actions-runner-linux-x64-$actions_runner_version.tar.gz )
+    exit  # `reboot` does not exit
 fi
 
 if ! [ -e image-built ]; then
+    install_github_actions_runner
     touch image-built
     poweroff
+    exit  # `poweroff` does not exit
+else
+    start_github_actions_runner
 fi
-
-export RUNNER_ALLOW_RUNASROOT=1
-curl -fsS --max-time 5 --retry 99 --retry-all-errors http://192.168.100.1:8000/github-jitconfig | jq -er . > jitconfig
-actions-runner/run.sh --jitconfig $(cat jitconfig)

--- a/ubuntu2204-rust/boot-script.sh
+++ b/ubuntu2204-rust/boot-script.sh
@@ -1,5 +1,43 @@
 #!/bin/sh
 set -eux
 
-echo hello world
-poweroff
+actions_runner_version=2.323.0
+
+download() (
+    set -x
+    curl -fsSLO "http://192.168.100.1:8000/image-deps/ubuntu2204/$1"
+)
+
+mkdir -p /ci
+cd /ci
+
+if ! [ -e image-expanded ]; then
+    touch image-expanded
+    reboot
+fi
+
+set -- jq  # Used further below
+
+# Install distro packages, but only if one or more are not already installed.
+# Update the package lists first, to avoid failures when rebaking old images.
+if ! dpkg -s "$@" > /dev/null 2>&1; then
+    apt update
+    # DEBIAN_FRONTEND needed to avoid hang when installing tshark
+    DEBIAN_FRONTEND=noninteractive apt install -y "$@"
+fi
+
+if ! [ -e actions-runner-linux-x64-$actions_runner_version.tar.gz ]; then
+    download actions-runner-linux-x64-$actions_runner_version.tar.gz
+    rm -Rf actions-runner
+    mkdir -p actions-runner
+    ( cd actions-runner; tar xf ../actions-runner-linux-x64-$actions_runner_version.tar.gz )
+fi
+
+if ! [ -e image-built ]; then
+    touch image-built
+    poweroff
+fi
+
+export RUNNER_ALLOW_RUNASROOT=1
+curl -fsS --max-time 5 --retry 99 --retry-all-errors http://192.168.100.1:8000/github-jitconfig | jq -er . > jitconfig
+actions-runner/run.sh --jitconfig $(cat jitconfig)

--- a/ubuntu2204-rust/boot-script.sh
+++ b/ubuntu2204-rust/boot-script.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eux
+
+echo hello world
+poweroff

--- a/ubuntu2204-rust/guest.xml
+++ b/ubuntu2204-rust/guest.xml
@@ -1,0 +1,189 @@
+<domain type='kvm'>
+  <name>servo-ubuntu2204-rust.init</name>
+  <uuid>ec747b67-ffb4-47cc-a27b-43156ca1724f</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://ubuntu.com/ubuntu/22.04"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory unit='KiB'>12582912</memory>
+  <currentMemory unit='KiB'>12582912</currentMemory>
+  <memoryBacking>
+    <hugepages/>
+  </memoryBacking>
+  <vcpu placement='static'>8</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-q35-8.1'>hvm</type>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state='off'/>
+  </features>
+  <cpu mode='host-passthrough' check='none' migratable='on'/>
+  <clock offset='utc'>
+    <timer name='rtc' tickpolicy='catchup'/>
+    <timer name='pit' tickpolicy='delay'/>
+    <timer name='hpet' present='no'/>
+  </clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+    <suspend-to-mem enabled='no'/>
+    <suspend-to-disk enabled='no'/>
+  </pm>
+  <devices>
+    <emulator>/run/libvirt/nix-emulators/qemu-system-x86_64</emulator>
+    <disk type='block' device='disk'>
+      <driver name='qemu' type='raw' cache='none' io='native' discard='unmap'/>
+      <!-- virt-clone(1) will replace this with the first `-f` -->
+      <source dev='/dev/null'/>
+      <target dev='vda' bus='virtio'/>
+      <boot order='1'/>
+      <address type='pci' domain='0x0000' bus='0x04' slot='0x00' function='0x0'/>
+    </disk>
+    <disk type='file' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <source file='/var/lib/libvirt/images/base/servo-ubuntu2204-rust.config.iso'/>
+      <target dev='sda' bus='sata'/>
+      <readonly/>
+      <boot order='2'/>
+      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+    </disk>
+    <controller type='usb' index='0' model='qemu-xhci' ports='15'>
+      <address type='pci' domain='0x0000' bus='0x02' slot='0x00' function='0x0'/>
+    </controller>
+    <controller type='pci' index='0' model='pcie-root'/>
+    <controller type='pci' index='1' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='1' port='0x10'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0' multifunction='on'/>
+    </controller>
+    <controller type='pci' index='2' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='2' port='0x11'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x1'/>
+    </controller>
+    <controller type='pci' index='3' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='3' port='0x12'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x2'/>
+    </controller>
+    <controller type='pci' index='4' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='4' port='0x13'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x3'/>
+    </controller>
+    <controller type='pci' index='5' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='5' port='0x14'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x4'/>
+    </controller>
+    <controller type='pci' index='6' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='6' port='0x15'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x5'/>
+    </controller>
+    <controller type='pci' index='7' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='7' port='0x16'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x6'/>
+    </controller>
+    <controller type='pci' index='8' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='8' port='0x17'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x7'/>
+    </controller>
+    <controller type='pci' index='9' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='9' port='0x18'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0' multifunction='on'/>
+    </controller>
+    <controller type='pci' index='10' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='10' port='0x19'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x1'/>
+    </controller>
+    <controller type='pci' index='11' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='11' port='0x1a'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x2'/>
+    </controller>
+    <controller type='pci' index='12' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='12' port='0x1b'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x3'/>
+    </controller>
+    <controller type='pci' index='13' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='13' port='0x1c'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x4'/>
+    </controller>
+    <controller type='pci' index='14' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='14' port='0x1d'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x5'/>
+    </controller>
+    <controller type='sata' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x1f' function='0x2'/>
+    </controller>
+    <controller type='virtio-serial' index='0'>
+      <address type='pci' domain='0x0000' bus='0x03' slot='0x00' function='0x0'/>
+    </controller>
+    <interface type='network'>
+      <mac address='52:54:00:b8:b3:dd'/>
+      <source network='cinet'/>
+      <model type='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <channel type='unix'>
+      <target type='virtio' name='org.qemu.guest_agent.0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='1'/>
+    </channel>
+    <channel type='spicevmc'>
+      <target type='virtio' name='com.redhat.spice.0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='2'/>
+    </channel>
+    <input type='tablet' bus='usb'>
+      <address type='usb' bus='0' port='1'/>
+    </input>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type='spice' autoport='yes'>
+      <listen type='address'/>
+      <image compression='off'/>
+    </graphics>
+    <sound model='ich9'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x1b' function='0x0'/>
+    </sound>
+    <audio id='1' type='spice'/>
+    <video>
+      <model type='virtio' heads='1' primary='yes'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
+    </video>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='2'/>
+    </redirdev>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='3'/>
+    </redirdev>
+    <watchdog model='itco' action='reset'/>
+    <memballoon model='virtio'>
+      <address type='pci' domain='0x0000' bus='0x05' slot='0x00' function='0x0'/>
+    </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+      <address type='pci' domain='0x0000' bus='0x06' slot='0x00' function='0x0'/>
+    </rng>
+  </devices>
+</domain>
+

--- a/ubuntu2204-rust/guest.xml
+++ b/ubuntu2204-rust/guest.xml
@@ -43,9 +43,8 @@
       <boot order='1'/>
       <address type='pci' domain='0x0000' bus='0x04' slot='0x00' function='0x0'/>
     </disk>
-    <disk type='file' device='cdrom'>
+    <disk type='block' device='cdrom'>
       <driver name='qemu' type='raw'/>
-      <source file='/var/lib/libvirt/images/base/servo-ubuntu2204-rust.config.iso'/>
       <target dev='sda' bus='sata'/>
       <readonly/>
       <boot order='2'/>

--- a/ubuntu2204-rust/meta-data
+++ b/ubuntu2204-rust/meta-data
@@ -1,0 +1,1 @@
+../ubuntu2204/meta-data

--- a/ubuntu2204-rust/user-data
+++ b/ubuntu2204-rust/user-data
@@ -26,6 +26,7 @@ MIME-Version: 1.0
 Content-Transfer-Encoding: binary
 
 #!/bin/sh
+set -eux
 # This script runs on every boot, near the start of cloud-init.
 # https://docs.cloud-init.io/en/24.1/reference/datasources/nocloud.html#file-formats
 # https://docs.cloud-init.io/en/latest/explanation/format.html#cloud-boothook
@@ -67,7 +68,7 @@ cloud-init-per instance netplan-generate  netplan generate
 cloud-init-per instance netplan-apply  netplan apply
 
 # Run the boot script
-systemd-cat  curl -fsSo /usr/local/bin/servo-ci-boot http://192.168.100.1:8000/boot
+systemd-cat  curl -fsSo /usr/local/bin/servo-ci-boot --max-time 5 --retry 99 --retry-all-errors http://192.168.100.1:8000/boot
 systemd-cat  chmod +x /usr/local/bin/servo-ci-boot
 systemd-cat  /usr/local/bin/servo-ci-boot
 

--- a/ubuntu2204-rust/user-data
+++ b/ubuntu2204-rust/user-data
@@ -68,9 +68,9 @@ cloud-init-per instance netplan-generate  netplan generate
 cloud-init-per instance netplan-apply  netplan apply
 
 # Run the boot script
-systemd-cat  curl -fsSo /usr/local/bin/servo-ci-boot --max-time 5 --retry 99 --retry-all-errors http://192.168.100.1:8000/boot
-systemd-cat  chmod +x /usr/local/bin/servo-ci-boot
-systemd-cat  /usr/local/bin/servo-ci-boot
+systemd-cat -t ci  curl -fsSo /usr/local/bin/servo-ci-boot --max-time 5 --retry 99 --retry-all-errors http://192.168.100.1:8000/boot
+systemd-cat -t ci  chmod +x /usr/local/bin/servo-ci-boot
+systemd-cat -t ci  /usr/local/bin/servo-ci-boot
 
 --==part==
 Content-Type: text/x-shellscript; charset="utf-8"

--- a/ubuntu2204-rust/user-data
+++ b/ubuntu2204-rust/user-data
@@ -1,0 +1,85 @@
+Content-Type: multipart/mixed; boundary="==part=="
+MIME-Version: 1.0
+Number-Attachments: 3
+
+--==part==
+Content-Type: text/cloud-config; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: binary
+
+# https://docs.cloud-init.io/en/24.1/reference/datasources/nocloud.html#file-formats
+# https://docs.cloud-init.io/en/24.1/explanation/format.html#cloud-config-data
+
+password: "servo2024!"
+chpasswd:
+  expire: False
+ssh_authorized_keys:
+  # Keep this in sync with server/nixos/configuration.nix
+  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGEpS5yFUgXwOf9rkw/TdZgoWkfAgLYwABGiK7qAWsHR root@ci0
+  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICBvkS7z2RAWzqRByRsHHB8PoCjXrnyHtjpdTxmOdcom delan@azabani.com/2016-07-18/Ed25519
+  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPag2UMaWyIEIsL0EbdvChBCcARVxNeJAplUZe70kXlr mrobinson@igalia.com
+  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIPiTpwVkwvE8npI7Z944tmrFlPKDjDVbm1rI7m4lng7 me@mukilan
+
+--==part==
+Content-Type: text/cloud-boothook; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: binary
+
+#!/bin/sh
+# This script runs on every boot, near the start of cloud-init.
+# https://docs.cloud-init.io/en/24.1/reference/datasources/nocloud.html#file-formats
+# https://docs.cloud-init.io/en/latest/explanation/format.html#cloud-boothook
+
+# On first boot, configure journald.conf(5) to print logs to tty7 and restart journald.
+# This means we print logs to tty7 on every boot, including the first boot. We use a
+# boothook here, instead of write_files + cc_scripts_user, because boothooks run much
+# earlier, so more logs will be readable.
+# https://manpages.ubuntu.com/manpages/jammy/en/man1/cloud-init-per.1.html
+cloud-init-per instance configure-journald  tee -a /etc/systemd/journald.conf <<'EOF'
+ForwardToConsole=yes
+MaxLevelConsole=debug
+TTYPath=/dev/tty7
+EOF
+cloud-init-per instance restart-journald  systemctl restart systemd-journald
+
+# On every boot, switch to tty7, which displays logs only and has no getty.
+chvt 7
+
+# The fallback network config is inappropriate for our needs, because it bakes
+# the MAC address into the netplan config, which breaks virt-clone(1).
+# https://docs.cloud-init.io/en/24.1/reference/network-config.html#fallback-network-configuration
+
+# This network config will survive cloning, but for some reason, maybe a bug,
+# we have to write the file and bring the network up ourselves. If we use a
+# network-config file, cloud-init will write the file and `netplan generate`,
+# but never seems to actually apply it. When this happens, the guest will hang
+# for a while, blocking cloud-init and leaving us with an unreachable guest.
+cloud-init-per instance no-cloud-init-networking  rm /etc/netplan/50-cloud-init.yaml
+cloud-init-per instance configure-netplan  tee /etc/netplan/99-local.yaml <<'EOF'
+network:
+  version: 2
+  ethernets:
+    enp1s0:
+      dhcp4: true
+      dhcp6: true
+EOF
+cloud-init-per instance netplan-generate  netplan generate
+cloud-init-per instance netplan-apply  netplan apply
+
+--==part==
+Content-Type: text/x-shellscript; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: binary
+
+#!/bin/sh
+set -eux
+# This script runs once, near the end of cloud-init.
+# https://docs.cloud-init.io/en/24.1/reference/datasources/nocloud.html#file-formats
+# https://docs.cloud-init.io/en/24.1/explanation/format.html#user-data-script
+
+# Run the boot script
+systemd-cat  curl -fsSo /usr/local/bin/servo-ci-boot http://192.168.100.1:8000/boot
+systemd-cat  chmod +x /usr/local/bin/servo-ci-boot
+systemd-cat  /usr/local/bin/servo-ci-boot
+
+--==part==--

--- a/ubuntu2204-rust/user-data
+++ b/ubuntu2204-rust/user-data
@@ -20,6 +20,14 @@ ssh_authorized_keys:
   - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPag2UMaWyIEIsL0EbdvChBCcARVxNeJAplUZe70kXlr mrobinson@igalia.com
   - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIPiTpwVkwvE8npI7Z944tmrFlPKDjDVbm1rI7m4lng7 me@mukilan
 
+# Avoid depending on external pollinate servers
+random_seed:
+  command: ['sh', '-c', 'dd if=/dev/urandom of=$RANDOM_SEED_FILE count=2048']
+  command_required: true
+  data: my random string
+  encoding: raw
+  file: /dev/urandom
+
 --==part==
 Content-Type: text/cloud-boothook; charset="utf-8"
 MIME-Version: 1.0

--- a/ubuntu2204-rust/user-data
+++ b/ubuntu2204-rust/user-data
@@ -66,6 +66,11 @@ EOF
 cloud-init-per instance netplan-generate  netplan generate
 cloud-init-per instance netplan-apply  netplan apply
 
+# Run the boot script
+systemd-cat  curl -fsSo /usr/local/bin/servo-ci-boot http://192.168.100.1:8000/boot
+systemd-cat  chmod +x /usr/local/bin/servo-ci-boot
+systemd-cat  /usr/local/bin/servo-ci-boot
+
 --==part==
 Content-Type: text/x-shellscript; charset="utf-8"
 MIME-Version: 1.0
@@ -76,10 +81,5 @@ set -eux
 # This script runs once, near the end of cloud-init.
 # https://docs.cloud-init.io/en/24.1/reference/datasources/nocloud.html#file-formats
 # https://docs.cloud-init.io/en/24.1/explanation/format.html#user-data-script
-
-# Run the boot script
-systemd-cat  curl -fsSo /usr/local/bin/servo-ci-boot http://192.168.100.1:8000/boot
-systemd-cat  chmod +x /usr/local/bin/servo-ci-boot
-systemd-cat  /usr/local/bin/servo-ci-boot
 
 --==part==--

--- a/ubuntu2204-rust/user-data
+++ b/ubuntu2204-rust/user-data
@@ -75,20 +75,21 @@ EOF
 cloud-init-per instance netplan-generate  netplan generate
 cloud-init-per instance netplan-apply  netplan apply
 
-# Run the boot script
-systemd-cat -t ci  curl -fsSo /usr/local/bin/servo-ci-boot --max-time 5 --retry 99 --retry-all-errors http://192.168.100.1:8000/boot
-systemd-cat -t ci  chmod +x /usr/local/bin/servo-ci-boot
-systemd-cat -t ci  /usr/local/bin/servo-ci-boot
-
 --==part==
-Content-Type: text/x-shellscript; charset="utf-8"
+Content-Type: text/x-shellscript-per-boot; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: binary
 
 #!/bin/sh
 set -eux
-# This script runs once, near the end of cloud-init.
+# This script runs on every boot, near the end of cloud-init.
 # https://docs.cloud-init.io/en/24.1/reference/datasources/nocloud.html#file-formats
 # https://docs.cloud-init.io/en/24.1/explanation/format.html#user-data-script
+# https://docs.cloud-init.io/en/24.1/explanation/format.html#mime-multi-part-archive
+
+# Run the boot script
+systemd-cat -t ci  curl -fsSo /usr/local/bin/servo-ci-boot --max-time 5 --retry 99 --retry-all-errors http://192.168.100.1:8000/boot
+systemd-cat -t ci  chmod +x /usr/local/bin/servo-ci-boot
+systemd-cat -t ci  /usr/local/bin/servo-ci-boot
 
 --==part==--


### PR DESCRIPTION
This patch adds a proof-of-concept image (servo-ubuntu2204-rust) with a completely new architecture:

- No more mounting guest filesystems — this will [soon be impossible](https://github.com/servo/ci-runners/issues/30) on macOS images
- No more shelling out to scripts from the monitor — it’s janky and complicates monitor deployment
- No more juggling zvols — openzfs 2.3.0 supports reflink copies, so we can just use .img files

![Screenshot_ci-servo-ubuntu2204-rust 970_2025-05-12_15:14:21](https://github.com/user-attachments/assets/1fcf9a42-b8fa-49bf-ac34-c6d711e3bddf)