### PR TITLE
Minor updates to docker hos images

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -3,10 +3,9 @@
 set -eu
 
 SERVO_GIT_HASH=$(git ls-remote https://github.com/servo/servo.git --branches refs/heads/main | awk '{ print $1}')
-HOS_COMMANDLINE_TOOLS_VERSION="5.0.3.906"
-GITHUB_ACTIONS_RUNNER_VERSION="2.322.0"
+GITHUB_ACTIONS_RUNNER_VERSION="2.323.0"
 RUST_VERSION="1.85.0"
-UV_VERSION="0.6.4"
+UV_VERSION="0.6.14"
 IMAGE_USERNAME=servo_ci
 
 
@@ -16,20 +15,12 @@ then
     cd hos_builder && wget https://cli.github.com/packages/githubcli-archive-keyring.gpg && cd -
 fi
 
-if [[ ! -f "hos_commandline_tools/commandline-tools-linux-x64-${HOS_COMMANDLINE_TOOLS_VERSION}.zip" ]]
-then
-    echo "Couldn't find the HarmonyOS commandline tools (version ${HOS_COMMANDLINE_TOOLS_VERSION}). Please download manually."
-    echo "The commandline tools can be found at https://developer.huawei.com/consumer/cn/download/"
-    echo "Note: Currently the commandline tools are only available to developers with a mainland china huawei account."
-    exit 1
-fi
-
 # Build the helper images
 docker build base -f base/Dockerfile -t servo_gha_base:latest --build-arg=USERNAME=${IMAGE_USERNAME}
 docker build gh_runner -f gh_runner/Dockerfile -t "servo_gha_runner:${GITHUB_ACTIONS_RUNNER_VERSION}" \
     --build-arg=USERNAME=${IMAGE_USERNAME} \
     --build-arg=GITHUB_ACTIONS_RUNNER_VERSION=${GITHUB_ACTIONS_RUNNER_VERSION}
-docker build hos_commandline_tools -f hos_commandline_tools/Dockerfile -t "hos_commandline_tools:${HOS_COMMANDLINE_TOOLS_VERSION}" \
+docker build hos_commandline_tools -f hos_commandline_tools/Dockerfile -t "hos_commandline_tools" \
    --build-arg=USERNAME=${IMAGE_USERNAME}
 
 # Build the actual images

--- a/docker/hos_commandline_tools/Dockerfile
+++ b/docker/hos_commandline_tools/Dockerfile
@@ -1,5 +1,6 @@
 FROM servo_gha_base:latest
 
 RUN mkdir -p data
-ADD commandline-tools-linux-x64-5.0.3.906.zip /data/commandline-tools.zip
+ARG COMMANDLINE_TOOLS_PATH=https://repo.huaweicloud.com/harmonyos/ohpm/5.0.5/commandline-tools-linux-x64-5.0.5.310.zip
+ADD ${COMMANDLINE_TOOLS_PATH} /data/commandline-tools.zip
 RUN cd data && unzip -q commandline-tools.zip

--- a/docker/runner/Dockerfile
+++ b/docker/runner/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=commandline_tools /data/command-line-tools/sdk/default/openharmony/t
 # Note: We could solve this via Github secrets, but that would require first auditing all
 # servo workflows. I suspect that it is currently possible to extract secrets from the servo repo
 # via pull requests with malicous build scripts.
-ADD ohos-config.tar /home/${USERNAME}/
+ADD --chown=${USERNAME}:${USERNAME} ohos-config.tar /home/${USERNAME}/
 # Used to authorize with the hdc device and avoid the confirmation dialog.
 COPY --chown=${USERNAME}:${USERNAME} hdckey hdckey.pub /home/${USERNAME}/.harmony/
 ADD hdc.tar /usr/bin/


### PR DESCRIPTION
- Fix permissions for ohos-config.tar
- Bump dependencies (uv, github runner, commandline tools)
- Download command line tools automatically.