### PR TITLE
Update hitrace-bench version for new filters

### DIFF
--- a/docker/runner/Dockerfile
+++ b/docker/runner/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update && apt install -y curl build-essential
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --default-toolchain stable \
         --profile=minimal
-RUN /root/.cargo/bin/cargo install hitrace-bench --version 0.2.2
+RUN /root/.cargo/bin/cargo install hitrace-bench --version 0.2.4
 
 FROM hos_commandline_tools:${HOS_COMMANDLINE_TOOLS_VERSION} AS commandline_tools
 


### PR DESCRIPTION
Update hitrace version for new filters.
Originally we used `Load Status change started` but that does not seem to be emitted anymore. So we changed to HeadParsed.
The changes to hitrace-bench can be seen here: https://github.com/openharmony-rs/hitrace-bench/commit/416472e03ae7acd3866d2de407ed0ded0d39f963

Ideally we probably want to read the filters from a file in the future.

I tested these changes on the OHOS spare infrastructure.