### PR TITLE
docker: Cleanup running containers when monitor is stopped

### DIFF
--- a/docker/docker_jit_monitor/servo_ci.service
+++ b/docker/docker_jit_monitor/servo_ci.service
@@ -7,6 +7,7 @@ Environment="DOCKER_HOST=unix:///run/user/<USERID>/docker.sock"
 Environment="GITHUB_TOKEN=<INSERT YOUR TOKEN>"
 Environment="SERVO_CI_GITHUB_API_SCOPE=<YOUR API SCOPE, /repos/servo/servo>"
 ExecStart=/home/servo_ci/ci-runners/docker/docker_jit_monitor/target/release/docker_jit_monitor
+ExecStopPost=sh -c 'docker ps -q | xargs docker stop'
 ProtectKernelModules=no
 RestrictSUIDSGID=yes
 RestrictRealtime=yes


### PR DESCRIPTION
This is technically a bit too much because we might have other
containers that are not started by the CI but I think this is a valid
change for now.
It also improves the handling of stopping the service. Previously
systemd was waiting for the containers to stop but could not kill them,
so this improves the time needed for servo_ci stop or restart.
