### PR TITLE
Update hitrace-bencher version to allow memory reporting.

### DIFF
--- a/docker/runner/Dockerfile
+++ b/docker/runner/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update && apt install -y curl build-essential
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --default-toolchain stable \
         --profile=minimal
-RUN /root/.cargo/bin/cargo install hitrace-bench --version 0.2.2
+RUN /root/.cargo/bin/cargo install hitrace-bench --version 0.5.0
 
 FROM hos_commandline_tools:${HOS_COMMANDLINE_TOOLS_VERSION} AS commandline_tools
 


### PR DESCRIPTION
Already deployed on the CI.
Replaces https://github.com/servo/ci-runners/pull/36/files


Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
