### PR TITLE
OHOS: Robustify the runners

### DIFF
--- a/docker/docker_jit_monitor/src/main.rs
+++ b/docker/docker_jit_monitor/src/main.rs
@@ -1,9 +1,8 @@
 use serde_json::Value;
 use std::{
-    process::{self, Command, ExitStatus},
+    process::{self, Command},
     string::FromUtf8Error,
     sync::atomic::{AtomicU32, AtomicU64, Ordering},
-    thread,
     time::Duration,
 };
 use thiserror::Error;


### PR DESCRIPTION
This involves a couple of changes:

- Upgrade Dependencies
- Have a new function `check_and_inc_retries` that will panic if the
  retries is too much without success. We will exit the process and
  crash. If we succeed we set the retries to zero.
- Unify processor timeout throughout main loop. Some paths through the
  main loop had some timeouts while some had none. We now have a unified
  timeout at the end (before killing offline runners) of 5 seconds.
- Read the env variable "RUNNER_SUFFIX" to add a suffix to the runner
  name, so we do not have to hardcode it.
- Introduce a new function `call_github_runner_api` which encapsulates
  simple github api calls with gh. `spawn_runner` now uses this new
  functionality for spawning. Previously some
- Introduce `kill_offline_runners` which calsl the github api for
  current runners, takes runners that are offline and have a name
  starting with `dresden-hos`. Then it removes these runners. This happens
  at the end and 5 seconds after we started the runners. The runners need
  some time to start and connect to github properly. The timeout seems ok
  but we can probably increase it.


Testing: Tested on runner CI2. It succesfully removed old offline runners on github and started new ones.
I plan to let CI2 run this new code for a bit to see if there are any regressions without changing CI1.

Hopefully this fixes: https://github.com/servo/ci-runners/issues/44

Sorry for the massive changes but I think the codebase is so small that
it is allowed :D


