### PR TITLE
monitor: store all runner image files in one directory

### DIFF
--- a/monitor/src/image.rs
+++ b/monitor/src/image.rs
@@ -367,9 +367,9 @@ pub(self) fn create_base_images_dir(profile: &Profile) -> eyre::Result<PathBuf> 
     Ok(base_images_path)
 }
 
-pub(self) fn create_runner_images_dir(runner_id: usize) -> eyre::Result<PathBuf> {
-    let runner_images_path = runner_images_path(runner_id);
-    debug!(?runner_images_path, "Creating runner images subdirectory");
+pub(self) fn create_runner_images_dir() -> eyre::Result<PathBuf> {
+    let runner_images_path = runner_images_path();
+    debug!(?runner_images_path, "Creating runner images directory");
     create_dir_all(&runner_images_path)?;
 
     Ok(runner_images_path)

--- a/monitor/src/image/macos13.rs
+++ b/monitor/src/image/macos13.rs
@@ -19,7 +19,7 @@ use crate::image::libvirt_change_media;
 use crate::image::prune_base_image_files;
 use crate::image::undefine_libvirt_guest;
 use crate::image::CdromImage;
-use crate::policy::runner_images_path;
+use crate::policy::runner_image_path;
 use crate::shell::atomic_symlink;
 use crate::shell::log_output_as_info;
 use crate::shell::reflink_or_copy_with_warning;
@@ -125,8 +125,8 @@ pub fn create_runner(
     // because the latter can’t be parallelised without causing errors.
     let base_images_path = create_base_images_dir(profile)?;
     let base_image_symlink_path = base_images_path.join(format!("base.img"));
-    let runner_images_path = create_runner_images_dir(runner_id)?;
-    let runner_base_image_path = runner_images_path.join(format!("base.img"));
+    create_runner_images_dir()?;
+    let runner_base_image_path = runner_image_path(runner_id, "base.img");
     reflink_or_copy_with_warning(&base_image_symlink_path, &runner_base_image_path)?;
 
     let ovmf_vars_base_path =
@@ -141,8 +141,7 @@ pub fn create_runner(
 }
 
 pub fn destroy_runner(runner_guest_name: &str, runner_id: usize) -> eyre::Result<()> {
-    let runner_images_path = runner_images_path(runner_id);
-    let runner_base_image_path = runner_images_path.join(format!("base.img"));
+    let runner_base_image_path = runner_image_path(runner_id, "base.img");
     if let Err(error) = remove_file(&runner_base_image_path) {
         warn!(?runner_base_image_path, ?error, "Failed to delete file");
     }

--- a/monitor/src/image/ubuntu2204.rs
+++ b/monitor/src/image/ubuntu2204.rs
@@ -18,7 +18,7 @@ use crate::image::create_runner_images_dir;
 use crate::image::delete_base_image_file;
 use crate::image::prune_base_image_files;
 use crate::image::undefine_libvirt_guest;
-use crate::policy::runner_images_path;
+use crate::policy::runner_image_path;
 use crate::shell::atomic_symlink;
 use crate::shell::log_output_as_info;
 use crate::shell::reflink_or_copy_with_warning;
@@ -144,8 +144,8 @@ pub fn create_runner(
     // TODO copy config.iso?
     let base_images_path = create_base_images_dir(profile)?;
     let base_image_symlink_path = base_images_path.join(format!("base.img"));
-    let runner_images_path = create_runner_images_dir(runner_id)?;
-    let runner_base_image_path = runner_images_path.join(format!("base.img"));
+    create_runner_images_dir()?;
+    let runner_base_image_path = runner_image_path(runner_id, "base.img");
     reflink_or_copy_with_warning(&base_image_symlink_path, &runner_base_image_path)?;
 
     spawn_with_output!(virt-clone -o $profile_guest_name -n $runner_guest_name --preserve-data -f $runner_base_image_path 2>&1)?
@@ -156,8 +156,7 @@ pub fn create_runner(
 
 pub fn destroy_runner(runner_guest_name: &str, runner_id: usize) -> eyre::Result<()> {
     // TODO delete config.iso?
-    let runner_images_path = runner_images_path(runner_id);
-    let runner_base_image_path = runner_images_path.join(format!("base.img"));
+    let runner_base_image_path = runner_image_path(runner_id, "base.img");
     if let Err(error) = remove_file(&runner_base_image_path) {
         warn!(?runner_base_image_path, ?error, "Failed to delete file");
     }

--- a/monitor/src/policy.rs
+++ b/monitor/src/policy.rs
@@ -874,8 +874,8 @@ pub fn base_images_path(profile: &Profile) -> PathBuf {
     Path::new("/var/lib/libvirt/images/base").join(&profile.profile_name)
 }
 
-pub fn runner_images_path(runner_id: usize) -> PathBuf {
-    Path::new("/var/lib/libvirt/images/runner").join(&format!("{runner_id}"))
+pub fn runner_images_path() -> PathBuf {
+    PathBuf::from("/var/lib/libvirt/images/runner")
 }
 
 pub fn base_image_path<'snap>(
@@ -887,6 +887,10 @@ pub fn base_image_path<'snap>(
     } else {
         base_images_path(profile).join("base.img")
     }
+}
+
+pub fn runner_image_path(runner_id: usize, filename: impl AsRef<str>) -> PathBuf {
+    runner_images_path().join(format!("{runner_id}-{}", filename.as_ref()))
 }
 
 fn read_base_image_snapshot(profile: &Profile) -> eyre::Result<Option<String>> {


### PR DESCRIPTION
libvirt has a concept of “storage pools” where every disk attached to a guest must be part of a pool. for disk images that are files, a pool gets created for the containing directory, and never gets cleaned up. as a result, storing each runner’s disks in a separate subdirectory creates one pool for each runner (#52).

this patch fixes #52 by storing the disk images for all runners in `/var/lib/libvirt/images/runner`:
- before: `/var/lib/libvirt/images/runner/<runner_id>/base.img`
- after: `/var/lib/libvirt/images/runner/<runner_id>-base.img`

<img width="804" height="630" alt="image" src="https://github.com/user-attachments/assets/84bdc8c5-861a-4263-839c-538d446a5b27" />