### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-/  @delan
+*  @delan
 /actions/  @delan @sagudev
 /docker/  @jschwe


### PR DESCRIPTION
`/` doesn’t work in CODEOWNERS, and apparently doesn’t work in gitignore files either. huh.

<img width="657" height="191" alt="image" src="https://github.com/user-attachments/assets/1c9cd20a-62a5-4258-8a63-0a24a06a387d" />