### PR TITLE
windows10: Add bash to PATH

### DIFF
--- a/profiles/servo-windows10/boot-script
+++ b/profiles/servo-windows10/boot-script
@@ -22,7 +22,11 @@ if (!(Test-Path .\image-built)) {
     # Note: installer automatically uninstalls first if needed, so the check is just there to save time
     if (!(Test-Path 'C:\Program Files\Git\cmd\git.exe')) {
         curl.exe -fsSLO 'http://192.168.100.1:8000/image-deps/windows10/Git-2.45.1-64-bit.exe'; Check
-        .\Git-2.45.1-64-bit.exe /silent | Out-Default; Check
+        # `CmdTools` is “Use Git and optional Unix tools from the Command Prompt”, and is required
+        # by many composite actions expecting to be able to run bash scripts on all platforms.
+        # This is what GitHub’s images use, and it does not seem to override stock Windows tools.
+        # <https://github.com/git-for-windows/build-extra/pull/653>
+        .\Git-2.45.1-64-bit.exe /silent /o:PathOption=CmdTools | Out-Default; Check
     }
 
     # Install Python, for checkouts without servo#34504


### PR DESCRIPTION
this patch fixes #53 by adding bash to PATH in the same way as [github’s own images](https://github.com/actions/runner-images/blob/aab6e2778741c10551dca5dba356433b7fa1a6df/images/windows/scripts/build/Install-Git.ps1#L29).

this option doesn’t actually seem to override stock windows tools like `find` and `sort` until you’re _inside_ bash (git-for-windows/build-extra#653), so i think we can do this without any unwanted side effects.

<img width="1024" height="768" alt="Screenshot_servo-windows10_2025-11-05_12:23:39" src="https://github.com/user-attachments/assets/4d86bec4-d228-4205-b4ff-259e7977972c" />