### PR TITLE
monitor: don’t expose jitconfig token in API

### DIFF
--- a/monitor/src/runner.rs
+++ b/monitor/src/runner.rs
@@ -35,6 +35,7 @@ pub struct Runner {
     registration: Option<ApiRunner>,
     guest_name: Option<String>,
     ipv4_address: Option<Ipv4Addr>,
+    #[serde(skip)]
     github_jitconfig: Option<String>,
     details: RunnerDetails,
 }


### PR DESCRIPTION
there’s no reason to expose these values, and doing so may make us vulnerable to rogue runners.