### PR TITLE
Windows: Remove MFC component from boot script

### DIFF
--- a/profiles/servo-windows10/boot-script
+++ b/profiles/servo-windows10/boot-script
@@ -87,7 +87,6 @@ if (!(Test-Path .\image-built)) {
             --add Microsoft.VisualStudio.Component.Windows10SDK.19041 `
             --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
             --add Microsoft.VisualStudio.Component.VC.ATL `
-            --add Microsoft.VisualStudio.Component.VC.ATLMFC `
             --passive | Out-Default; Check
         # FIXME: rebooting here as a speculative fix for choco hanging during warm.ps1
         shutdown /r /t 0


### PR DESCRIPTION
This aligns with https://github.com/servo/mozjs/pull/626
Apparently, most other components had already been removed here before https://github.com/servo/mozjs/pull/626.

Reference: https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022