### PR TITLE
monitor: One-to-one relationship between guests and images

### DIFF
--- a/monitor.toml.example
+++ b/monitor.toml.example
@@ -52,6 +52,12 @@ base_image_max_age = 86400
 # Uncomment to skip cached Servo repo updates.
 # dont_update_cached_servo_repo = true
 
+# Create libvirt guests for profile templates as “ci-template-<profile_name>.0”. Namespace must not be used by anything else!
+# libvirt_template_guest_prefix = "ci-template"
+
+# Create libvirt guests for image rebuilds as “ci-rebuild-<profile_name>.0”. Namespace must not be used by anything else!
+# libvirt_rebuild_guest_prefix = "ci-rebuild"
+
 # Create libvirt guests for runners as “ci-runner-<profile_name>.0”. Namespace must not be used by anything else!
 # libvirt_runner_guest_prefix = "ci-runner"
 

--- a/monitor/settings/src/lib.rs
+++ b/monitor/settings/src/lib.rs
@@ -80,6 +80,8 @@ pub struct Toml {
     pub main_repo_path: String,
     base_image_max_age: u64,
     dont_update_cached_servo_repo: Option<bool>,
+    libvirt_template_guest_prefix: Option<String>,
+    libvirt_rebuild_guest_prefix: Option<String>,
     libvirt_runner_guest_prefix: Option<String>,
     pub available_1g_hugepages: usize,
     pub available_normal_memory: MemorySize,
@@ -240,6 +242,18 @@ impl Toml {
 
     pub fn queue_member(&self) -> bool {
         self.queue_member.unwrap_or(false)
+    }
+
+    pub fn libvirt_template_guest_prefix(&self) -> &str {
+        self.libvirt_template_guest_prefix
+            .as_deref()
+            .unwrap_or("ci-template")
+    }
+
+    pub fn libvirt_rebuild_guest_prefix(&self) -> &str {
+        self.libvirt_rebuild_guest_prefix
+            .as_deref()
+            .unwrap_or("ci-rebuild")
     }
 
     pub fn libvirt_runner_guest_prefix(&self) -> &str {

--- a/monitor/src/image/ubuntu2204.rs
+++ b/monitor/src/image/ubuntu2204.rs
@@ -7,18 +7,18 @@ use bytesize::ByteSize;
 use cmd_lib::run_cmd;
 use cmd_lib::spawn_with_output;
 use jane_eyre::eyre;
-use jane_eyre::eyre::OptionExt;
 use settings::profile::Profile;
 use tracing::info;
 use tracing::warn;
 
 use crate::data::get_profile_configuration_path;
-use crate::image::create_base_images_dir;
+use crate::data::get_profile_data_path;
 use crate::image::create_runner_images_dir;
-use crate::image::delete_base_image_file;
-use crate::image::prune_base_image_files;
+use crate::image::delete_template_or_rebuild_image_file;
+use crate::image::rename_guest;
 use crate::image::undefine_libvirt_guest;
 use crate::policy::runner_image_path;
+use crate::policy::template_or_rebuild_image_path;
 use crate::shell::atomic_symlink;
 use crate::shell::log_output_as_info;
 use crate::shell::reflink_or_copy_with_warning;
@@ -38,16 +38,14 @@ pub(super) fn rebuild(
     wait_duration: Duration,
 ) -> eyre::Result<()> {
     let base_images_path = base_images_path.as_ref();
-    let profile_guest_name = &profile.profile_guest_name();
+    let rebuild_guest_name = &profile.rebuild_guest_name(snapshot_name);
     let profile_configuration_path = get_profile_configuration_path(&profile, None)?;
-    let config_iso_symlink_path = base_images_path.join(format!("config.iso"));
     let config_iso_filename = format!("config.iso@{snapshot_name}");
     let config_iso_path = base_images_path.join(&config_iso_filename);
     let config_iso_path = config_iso_path.to_str().expect("Unsupported path");
     info!(config_iso_path, "Creating config image file");
     run_cmd!(genisoimage -V CIDATA -R -f -o $config_iso_path $profile_configuration_path/user-data $profile_configuration_path/meta-data)?;
 
-    let base_image_symlink_path = base_images_path.join(format!("base.img"));
     let os_image_path = IMAGE_DEPS_DIR
         .join("ubuntu2204")
         .join("jammy-server-cloudimg-amd64.raw");
@@ -60,53 +58,33 @@ pub(super) fn rebuild(
 
     define_base_guest(
         profile,
+        snapshot_name,
         &base_image_path,
         &[CdromImage::new("sda", config_iso_path)],
     )?;
-    start_libvirt_guest(profile_guest_name)?;
-    wait_for_guest(profile_guest_name, wait_duration)?;
+    start_libvirt_guest(rebuild_guest_name)?;
+    wait_for_guest(rebuild_guest_name, wait_duration)?;
 
-    let base_image_filename = Path::new(
-        base_image_path
-            .file_name()
-            .expect("Guaranteed by make_disk_image"),
-    );
-    atomic_symlink(config_iso_filename, config_iso_symlink_path)?;
-    atomic_symlink(base_image_filename, base_image_symlink_path)?;
-
-    Ok(())
-}
-
-pub(super) fn redefine_base_guest_with_symlinks(
-    base_images_path: impl AsRef<Path>,
-    profile: &Profile,
-) -> Result<(), eyre::Error> {
-    let base_images_path = base_images_path.as_ref();
-    let config_iso_symlink_path = base_images_path.join(format!("config.iso"));
-    let config_iso_symlink_path = config_iso_symlink_path
-        .to_str()
-        .ok_or_eyre("Unsupported path")?;
-    let base_image_symlink_path = base_images_path.join(format!("base.img"));
-    undefine_libvirt_guest(&profile.profile_guest_name())?;
-    define_base_guest(
-        profile,
-        &base_image_symlink_path,
-        &[CdromImage::new("sda", &config_iso_symlink_path)],
-    )?;
+    let template_guest_name = &profile.template_guest_name(snapshot_name);
+    rename_guest(rebuild_guest_name, template_guest_name)?;
+    let snapshot_symlink_path =
+        get_profile_data_path(&profile.profile_name, Path::new("snapshot"))?;
+    atomic_symlink(snapshot_name, snapshot_symlink_path)?;
 
     Ok(())
 }
 
 fn define_base_guest(
     profile: &Profile,
+    snapshot_name: &str,
     base_image_path: &dyn AsRef<OsStr>,
     cdrom_images: &[CdromImage],
 ) -> eyre::Result<()> {
-    let profile_guest_name = &profile.profile_guest_name();
+    let rebuild_guest_name = &profile.rebuild_guest_name(snapshot_name);
     let guest_xml_path = get_profile_configuration_path(&profile, Path::new("guest.xml"))?;
     define_libvirt_guest(
         &profile.profile_name,
-        profile_guest_name,
+        rebuild_guest_name,
         guest_xml_path,
         &[&"-f", &base_image_path],
         cdrom_images,
@@ -115,16 +93,11 @@ fn define_base_guest(
     Ok(())
 }
 
-pub(super) fn prune_images(profile: &Profile) -> eyre::Result<()> {
-    prune_base_image_files(profile, "config.iso")?;
-    prune_base_image_files(profile, "base.img")?;
-
+pub(super) fn delete_template(profile: &Profile, snapshot_name: &str) -> eyre::Result<()> {
+    undefine_libvirt_guest(&profile.template_guest_name(snapshot_name))?;
+    delete_template_or_rebuild_image_file(profile, &format!("config.iso@{snapshot_name}"));
+    delete_template_or_rebuild_image_file(profile, &format!("base.img@{snapshot_name}"));
     Ok(())
-}
-
-pub(super) fn delete_image(profile: &Profile, snapshot_name: &str) {
-    delete_base_image_file(profile, &format!("config.iso@{snapshot_name}"));
-    delete_base_image_file(profile, &format!("base.img@{snapshot_name}"));
 }
 
 pub fn register_runner(profile: &Profile, runner_guest_name: &str) -> eyre::Result<String> {
@@ -133,22 +106,22 @@ pub fn register_runner(profile: &Profile, runner_guest_name: &str) -> eyre::Resu
 
 pub fn create_runner(
     profile: &Profile,
+    snapshot_name: &str,
     runner_guest_name: &str,
     runner_id: usize,
 ) -> eyre::Result<String> {
     let pipe = || |reader| log_output_as_info(reader);
-    let profile_guest_name = &profile.profile_guest_name();
+    let template_guest_name = &profile.template_guest_name(snapshot_name);
 
     // Copy images in the monitor, not with `virt-clone --auto-clone --reflink`,
     // because the latter can’t be parallelised without causing errors.
     // TODO copy config.iso?
-    let base_images_path = create_base_images_dir(profile)?;
-    let base_image_symlink_path = base_images_path.join(format!("base.img"));
+    let template_base_img = template_or_rebuild_image_path(profile, snapshot_name, "base.img");
     create_runner_images_dir()?;
-    let runner_base_image_path = runner_image_path(runner_id, "base.img");
-    reflink_or_copy_with_warning(&base_image_symlink_path, &runner_base_image_path)?;
+    let runner_base_img = runner_image_path(runner_id, "base.img");
+    reflink_or_copy_with_warning(&template_base_img, &runner_base_img)?;
 
-    spawn_with_output!(virt-clone -o $profile_guest_name -n $runner_guest_name --preserve-data -f $runner_base_image_path 2>&1)?
+    spawn_with_output!(virt-clone -o $template_guest_name -n $runner_guest_name --preserve-data -f $runner_base_img 2>&1)?
         .wait_with_pipe(&mut pipe())?;
 
     Ok(runner_guest_name.to_owned())

--- a/monitor/src/image/windows10.rs
+++ b/monitor/src/image/windows10.rs
@@ -7,18 +7,18 @@ use bytesize::ByteSize;
 use cmd_lib::run_cmd;
 use cmd_lib::spawn_with_output;
 use jane_eyre::eyre;
-use jane_eyre::eyre::OptionExt;
 use settings::profile::Profile;
 use tracing::info;
 use tracing::warn;
 
 use crate::data::get_profile_configuration_path;
-use crate::image::create_base_images_dir;
+use crate::data::get_profile_data_path;
 use crate::image::create_runner_images_dir;
-use crate::image::delete_base_image_file;
-use crate::image::prune_base_image_files;
+use crate::image::delete_template_or_rebuild_image_file;
+use crate::image::rename_guest;
 use crate::image::undefine_libvirt_guest;
 use crate::policy::runner_image_path;
+use crate::policy::template_or_rebuild_image_path;
 use crate::shell::atomic_symlink;
 use crate::shell::log_output_as_info;
 use crate::shell::reflink_or_copy_with_warning;
@@ -38,16 +38,14 @@ pub(super) fn rebuild(
     wait_duration: Duration,
 ) -> eyre::Result<()> {
     let base_images_path = base_images_path.as_ref();
-    let profile_guest_name = &profile.profile_guest_name();
+    let rebuild_guest_name = &profile.rebuild_guest_name(snapshot_name);
     let profile_configuration_path = get_profile_configuration_path(&profile, None)?;
-    let config_iso_symlink_path = base_images_path.join(format!("config.iso"));
     let config_iso_filename = format!("config.iso@{snapshot_name}");
     let config_iso_path = base_images_path.join(&config_iso_filename);
     let config_iso_path = config_iso_path.to_str().expect("Unsupported path");
     info!(config_iso_path, "Creating config image file");
     run_cmd!(genisoimage -J -f -o $config_iso_path $profile_configuration_path/autounattend.xml)?;
 
-    let base_image_symlink_path = base_images_path.join(format!("base.img"));
     let base_image_path =
         create_disk_image(base_images_path, snapshot_name, base_image_size, None)?;
 
@@ -62,6 +60,7 @@ pub(super) fn rebuild(
 
     define_base_guest(
         profile,
+        snapshot_name,
         &base_image_path,
         &[
             CdromImage::new("sdb", installer_iso_path),
@@ -69,64 +68,29 @@ pub(super) fn rebuild(
             CdromImage::new("sdd", config_iso_path),
         ],
     )?;
-    start_libvirt_guest(profile_guest_name)?;
-    wait_for_guest(profile_guest_name, wait_duration)?;
+    start_libvirt_guest(rebuild_guest_name)?;
+    wait_for_guest(rebuild_guest_name, wait_duration)?;
 
-    let base_image_filename = Path::new(
-        base_image_path
-            .file_name()
-            .expect("Guaranteed by make_disk_image"),
-    );
-    atomic_symlink(config_iso_filename, config_iso_symlink_path)?;
-    atomic_symlink(base_image_filename, base_image_symlink_path)?;
-
-    Ok(())
-}
-
-pub(super) fn redefine_base_guest_with_symlinks(
-    base_images_path: impl AsRef<Path>,
-    profile: &Profile,
-) -> Result<(), eyre::Error> {
-    let base_images_path = base_images_path.as_ref();
-    let config_iso_symlink_path = base_images_path.join(format!("config.iso"));
-    let config_iso_symlink_path = config_iso_symlink_path
-        .to_str()
-        .ok_or_eyre("Unsupported path")?;
-    let base_image_symlink_path = base_images_path.join(format!("base.img"));
-
-    let installer_iso_path = IMAGE_DEPS_DIR
-        .join("windows10")
-        .join("Win10_22H2_English_x64v1.iso");
-    let installer_iso_path = installer_iso_path.to_str().expect("Unsupported path");
-    let drivers_iso_path = IMAGE_DEPS_DIR
-        .join("windows10")
-        .join("virtio-win-0.1.240.iso");
-    let drivers_iso_path = drivers_iso_path.to_str().expect("Unsupported path");
-
-    undefine_libvirt_guest(&profile.profile_guest_name())?;
-    define_base_guest(
-        profile,
-        &base_image_symlink_path,
-        &[
-            CdromImage::new("sdb", installer_iso_path),
-            CdromImage::new("sdc", drivers_iso_path),
-            CdromImage::new("sdd", &config_iso_symlink_path),
-        ],
-    )?;
+    let template_guest_name = &profile.template_guest_name(snapshot_name);
+    rename_guest(rebuild_guest_name, template_guest_name)?;
+    let snapshot_symlink_path =
+        get_profile_data_path(&profile.profile_name, Path::new("snapshot"))?;
+    atomic_symlink(snapshot_name, snapshot_symlink_path)?;
 
     Ok(())
 }
 
 fn define_base_guest(
     profile: &Profile,
+    snapshot_name: &str,
     base_image_path: &dyn AsRef<OsStr>,
     cdrom_images: &[CdromImage],
 ) -> eyre::Result<()> {
-    let profile_guest_name = &profile.profile_guest_name();
+    let rebuild_guest_name = &profile.rebuild_guest_name(snapshot_name);
     let guest_xml_path = get_profile_configuration_path(&profile, Path::new("guest.xml"))?;
     define_libvirt_guest(
         &profile.profile_name,
-        profile_guest_name,
+        rebuild_guest_name,
         guest_xml_path,
         &[&"-f", &base_image_path],
         cdrom_images,
@@ -135,16 +99,11 @@ fn define_base_guest(
     Ok(())
 }
 
-pub(super) fn prune_images(profile: &Profile) -> eyre::Result<()> {
-    prune_base_image_files(profile, "config.iso")?;
-    prune_base_image_files(profile, "base.img")?;
-
+pub(super) fn delete_template(profile: &Profile, snapshot_name: &str) -> eyre::Result<()> {
+    undefine_libvirt_guest(&profile.template_guest_name(snapshot_name))?;
+    delete_template_or_rebuild_image_file(profile, &format!("config.iso@{snapshot_name}"));
+    delete_template_or_rebuild_image_file(profile, &format!("base.img@{snapshot_name}"));
     Ok(())
-}
-
-pub(super) fn delete_image(profile: &Profile, snapshot_name: &str) {
-    delete_base_image_file(profile, &format!("config.iso@{snapshot_name}"));
-    delete_base_image_file(profile, &format!("base.img@{snapshot_name}"));
 }
 
 pub fn register_runner(profile: &Profile, runner_guest_name: &str) -> eyre::Result<String> {
@@ -153,22 +112,22 @@ pub fn register_runner(profile: &Profile, runner_guest_name: &str) -> eyre::Resu
 
 pub fn create_runner(
     profile: &Profile,
+    snapshot_name: &str,
     runner_guest_name: &str,
     runner_id: usize,
 ) -> eyre::Result<String> {
     let pipe = || |reader| log_output_as_info(reader);
-    let profile_guest_name = &profile.profile_guest_name();
+    let template_guest_name = &profile.template_guest_name(snapshot_name);
 
     // Copy images in the monitor, not with `virt-clone --auto-clone --reflink`,
     // because the latter can’t be parallelised without causing errors.
     // TODO copy config.iso?
-    let base_images_path = create_base_images_dir(profile)?;
-    let base_image_symlink_path = base_images_path.join(format!("base.img"));
+    let template_base_img = template_or_rebuild_image_path(profile, snapshot_name, "base.img");
     create_runner_images_dir()?;
-    let runner_base_image_path = runner_image_path(runner_id, "base.img");
-    reflink_or_copy_with_warning(&base_image_symlink_path, &runner_base_image_path)?;
+    let runner_base_img = runner_image_path(runner_id, "base.img");
+    reflink_or_copy_with_warning(&template_base_img, &runner_base_img)?;
 
-    spawn_with_output!(virt-clone -o $profile_guest_name -n $runner_guest_name --preserve-data -f $runner_base_image_path 2>&1)?
+    spawn_with_output!(virt-clone -o $template_guest_name -n $runner_guest_name --preserve-data -f $runner_base_img 2>&1)?
         .wait_with_pipe(&mut pipe())?;
 
     Ok(runner_guest_name.to_owned())

--- a/monitor/src/libvirt.rs
+++ b/monitor/src/libvirt.rs
@@ -12,6 +12,30 @@ use tracing::debug;
 
 use crate::shell::log_output_as_trace;
 
+pub fn list_template_guests() -> eyre::Result<Vec<String>> {
+    // Output is not filtered by prefix, so we must filter it ourselves.
+    let prefix = format!("{}-", TOML.libvirt_template_guest_prefix());
+    let result = run_fun!(virsh list --name --all)?;
+    let result = result
+        .split_terminator('\n')
+        .filter(|name| name.starts_with(&prefix))
+        .map(str::to_owned);
+
+    Ok(result.collect())
+}
+
+pub fn list_rebuild_guests() -> eyre::Result<Vec<String>> {
+    // Output is not filtered by prefix, so we must filter it ourselves.
+    let prefix = format!("{}-", TOML.libvirt_rebuild_guest_prefix());
+    let result = run_fun!(virsh list --name --all)?;
+    let result = result
+        .split_terminator('\n')
+        .filter(|name| name.starts_with(&prefix))
+        .map(str::to_owned);
+
+    Ok(result.collect())
+}
+
 pub fn list_runner_guests() -> eyre::Result<Vec<String>> {
     // Output is not filtered by prefix, so we must filter it ourselves.
     let prefix = format!("{}-", TOML.libvirt_runner_guest_prefix());


### PR DESCRIPTION
so far, we’ve managed the lifecycle of an image like servo-ubuntu2204 like this:

- rebuild the image by building a new _profile guest_ (libvirt guest named “**servo-ubuntu2204**”)
  - destroy the guest with that name, if it exists
  - recreate the guest from profiles/servo-ubuntu2204/guest.xml
  - set the disk to /path/to/base/servo-ubuntu2204/base.img@[timestamp]
  - start the guest, so that it can install tooling, bake in cached builds, etc
  - destroy the libvirt guest
  - recreate the guest from profiles/servo-ubuntu2204/guest.xml
  - set the disk to /path/to/base/servo-ubuntu2204/base.img (symlink)
- if successful, symlink /path/to/base/servo-ubuntu2204/base.img to base.img@[timestamp]
- if unsuccessful, symlink /path/to/base/servo-ubuntu2204/base.img to base.img@[oldTimestamp]
- create runners by cloning that guest into each _runner guest_ (“**ci-runner-servo-ubuntu2204.[number]**”)
  - clone the disks, but not the guests, with the monitor (so it can be parallelised)
  - clone the guest, but not the disks, with virt-clone

that works well enough for our current setup with libvirt and ZFS, but some hypervisors, like UTM (#64), will require us to treat each virtual machine as a self-contained object, with its own configuration and image files. in UTM, it’s hard to destroy a guest without also destroying its disks.

this patch moves the monitor closer to that world, by avoiding the destroy-recreate-configure pattern in image rebuilds. the lifecycle for servo-ubuntu2204 images now looks like this:

- rebuild the image by building a new _rebuild guest_ (“**ci-rebuild-servo-ubuntu2204@[timestamp]**”)
  - create the guest from profiles/servo-ubuntu2204/guest.xml
  - set the disk to /path/to/base/servo-ubuntu2204/base.img@[timestamp]
  - start the guest, so that it can install tooling, bake in cached builds, etc
- if successful, convert that guest to a new _template guest_ (“**ci-template-servo-ubuntu2204@[timestamp]**”)
  - conversion just means renaming the guest from “ci-rebuild-…” to “ci-template-…”
- if unsuccessful, just destroy that guest
- create runners by cloning that guest into each _runner guest_ (“**ci-runner-servo-ubuntu2204.[number]**”)
  - clone the disks, but not the guests, with the monitor (so it can be parallelised)
  - clone the guest, but not the disks, with virt-clone

bonus: with this patch, failed rebuilds will no longer leave the template in an inconsistent state, with the old image data (good) but the new guest configuration (bad because it may be broken).

<img width="771" height="519" alt="image" src="https://github.com/user-attachments/assets/21898110-d243-401a-9e0d-8852d2b74a9a" />