### PR TITLE
queue: fix some minor deployment issues

### DIFF
--- a/monitor/src/bin/queue/index.html
+++ b/monitor/src/bin/queue/index.html
@@ -50,7 +50,7 @@
 
     async function update() {
         try {
-            const response = await fetch("/dashboard.txt", { signal: AbortSignal.timeout(3000) });
+            const response = await fetch("dashboard.txt", { signal: AbortSignal.timeout(3000) });
             if (response.status == 503) {
                 notice.className = "stale";
                 notice.textContent = "...";

--- a/server/nixos/monitor.nix
+++ b/server/nixos/monitor.nix
@@ -67,6 +67,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/bin
     ln -s ${monitorCrate}/bin/monitor $out/bin/monitor
     ln -s ${monitorCrate}/bin/chunker $out/bin/chunker
+    ln -s ${monitorCrate}/bin/queue $out/bin/queue
     mkdir -p $out/lib/monitor
     cp -R profiles $out/lib/monitor
     cp -R shared $out/lib/monitor
@@ -75,6 +76,9 @@ in stdenv.mkDerivation rec {
   postFixup = ''
     wrapProgram $out/bin/monitor --set PATH ${lib.makeBinPath buildInputs} \
       --set LIB_MONITOR_DIR $out/lib/monitor \
+      --set IMAGE_DEPS_DIR ${image-deps}
+    wrapProgram $out/bin/queue --set PATH ${lib.makeBinPath buildInputs} \
+      --set LIB_MONITOR_DIR $out/lib/queue \
       --set IMAGE_DEPS_DIR ${image-deps}
   '';
 }


### PR DESCRIPTION
this patch fixes a few issues that were found [while deploying](https://github.com/servo/ci-runners/pull/69#issuecomment-3568750820) #69:

- monitor.nix failed to install the `queue` binary and set the necessary env variables
- the dashboard page fetches a URL that does not work in prod

i’ve deployed this to ci0 since the issues were prod-only. test builds:
- [self-test in servo/ci-runners](https://github.com/servo/ci-runners/actions/runs/19621929953/job/56183619252#step:3:139) (fails due to #77)
- [self-test in delan/servo-ci-runners](https://github.com/delan/servo-ci-runners/actions/runs/19622195025/job/56184320939)
- try jobs in servo/servo
  - <https://github.com/servo/servo/actions/runs/19624074289/job/56189642435#step:2:161>
  - <https://github.com/servo/servo/actions/runs/19624077577/job/56189654083#step:2:161>
  - <https://github.com/servo/servo/actions/runs/19624079336/job/56189657185#step:2:161>
  - <https://github.com/servo/servo/actions/runs/19624089967/job/56189690571#step:2:161>
  - <https://github.com/servo/servo/actions/runs/19624100902/job/56189714525#step:2:161>
  - <https://github.com/servo/servo/actions/runs/19624102672/job/56189717605#step:2:161>