### PR TITLE
actions: Restore queueless select as “runner-select-queueless”

### DIFF
--- a/actions/runner-select-queueless/action.yml
+++ b/actions/runner-select-queueless/action.yml
@@ -1,0 +1,147 @@
+name: Select Self-hosted Runner
+inputs:
+  GITHUB_TOKEN:
+    required: true
+    type: string
+  github-hosted-runner-label:
+    required: true
+    type: string
+  self-hosted-image-name:
+    required: true
+    type: string
+  force-github-hosted-runner:
+    required: false
+    type: boolean
+    default: false
+  NO_SELF_HOSTED_RUNNERS:
+    required: false
+    type: string
+    default: ""
+outputs:
+  unique-id:
+    value: ${{ steps.init.outputs.unique_id }}
+  selected-runner-label:
+    value: ${{ steps.decision.outputs.selected_runner_label }}
+  runner-type-label:
+    value: ${{ steps.decision.outputs.runner_type_label }}
+  is-self-hosted:
+    value: ${{ steps.decision.outputs.is_self_hosted }}
+
+runs:
+  using: "composite"
+  # Selects a self-hosted runner if available, or else a GitHub-hosted runner.
+  # We generate a unique id for the workload, then ask our monitor API to
+  # reserve a self-hosted runner for us.
+  steps:
+    - id: init
+      shell: bash
+      run: |
+        github_hosted_runner_label='${{ inputs.github-hosted-runner-label }}'
+        self_hosted_image_name='${{ inputs.self-hosted-image-name }}'
+
+        set -euo pipefail
+
+        # Generate a unique id that allows the workload job to find the runner
+        # we are reserving for it (via runner labels), and allows the timeout
+        # job to find the workload job run (via the job’s friendly name), even
+        # if there are multiple instances in the workflow call tree.
+        unique_id=$(uuidgen)
+        echo "unique_id=$unique_id" | tee -a $GITHUB_OUTPUT
+
+        # Disable self-hosted runners by creating a repository variable named
+        # NO_SELF_HOSTED_RUNNERS with any non-empty value.
+        # <https://github.com/servo/servo/settings/variables/actions>
+        if [ -n '${{ inputs.NO_SELF_HOSTED_RUNNERS }}' ]; then
+          echo 'NO_SELF_HOSTED_RUNNERS is set!'
+          echo "disabled=true" | tee -a $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # Disable self-hosted runners by calling this action with
+        # `force-github-hosted-runner` set to true.
+        if [ '${{ inputs.force-github-hosted-runner }}' = true ]; then
+          echo 'inputs.force-github-hosted-runner is set!'
+          echo "disabled=true" | tee -a $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        echo "disabled=false" | tee -a $GITHUB_OUTPUT
+
+        artifact_path=$(mktemp)
+        echo "artifact_path=$artifact_path" | tee -a $GITHUB_OUTPUT
+
+        echo "unique_id=$unique_id" | tee -a "$artifact_path"
+        echo "self_hosted_image_name=$self_hosted_image_name" | tee -a "$artifact_path"
+        echo "qualified_repo=${{ github.repository }}" | tee -a "$artifact_path"
+        echo "run_id=${{ github.run_id }}" | tee -a "$artifact_path"
+
+    - id: artifact
+      name: Publish artifact with args
+      if: ${{ !fromJSON(steps.init.outputs.disabled) }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: servo-ci-runners_${{ steps.init.outputs.unique_id }}
+        path: ${{ steps.init.outputs.artifact_path }}
+        retention-days: 1
+
+    - id: decision
+      name: Find a server and reserve a runner
+      shell: bash
+      run: |
+        github_hosted_runner_label='${{ inputs.github-hosted-runner-label }}'
+        self_hosted_image_name='${{ inputs.self-hosted-image-name }}'
+        disabled='${{ steps.init.outputs.disabled }}'
+        unique_id='${{ steps.init.outputs.unique_id }}'
+
+        set -euo pipefail
+
+        fall_back_to_github_hosted() {
+          echo 'Falling back to GitHub-hosted runner'
+          echo "selected_runner_label=$github_hosted_runner_label" | tee -a $GITHUB_OUTPUT
+          echo "runner_type_label=$github_hosted_runner_label" | tee -a $GITHUB_OUTPUT
+          echo 'is_self_hosted=false' | tee -a $GITHUB_OUTPUT
+          exit 0
+        }
+
+        if [ "$disabled" = true ]; then
+          fall_back_to_github_hosted
+        fi
+
+        for monitor_api_base_url in $(printf \%s\\n \
+          https://ci0.servo.org \
+          https://ci1.servo.org \
+          https://ci2.servo.org \
+          https://ci3.servo.org \
+          https://ci4.servo.org \
+        | shuf); do
+          # Use the monitor API to reserve a runner. If we get an object with
+          # runner details, we succeeded. If we get null, we failed.
+          take_runner_url=$monitor_api_base_url/select-runner\?unique_id=$unique_id\&qualified_repo=${{ github.repository }}\&run_id=${{ github.run_id }}
+          result=$(mktemp)
+          echo
+          echo POST "$take_runner_url"
+          if curl -sS --fail-with-body --connect-timeout 5 --max-time 30 -X POST "$take_runner_url" > $result \
+              && jq -e . $result > /dev/null; then
+            echo
+            echo "selected_runner_label=reserved-for:$unique_id" | tee -a $GITHUB_OUTPUT
+            echo "runner_type_label=self-hosted-image:$self_hosted_image_name" | tee -a $GITHUB_OUTPUT
+            echo 'is_self_hosted=true' | tee -a $GITHUB_OUTPUT
+            exit 0
+          fi
+        done
+
+        cat $result
+        echo
+        echo
+        echo 'No self-hosted runners available!'
+        fall_back_to_github_hosted
+
+    - name: Delete args artifact
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        artifact_id='${{ steps.artifact.outputs.artifact-id }}'
+        GITHUB_TOKEN='${{ inputs.GITHUB_TOKEN }}' gh api \
+          -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' \
+          -X DELETE '/repos/${{ github.repository }}/actions/artifacts/'"$artifact_id" \
+        || :  # Don’t fail the build if this fails


### PR DESCRIPTION
queueing (#69) is a very new feature, so for now, running this CI system without a global queue is still supported.

this patch restores a copy of the old runner-select action as “runner-select-queueless”, until we decide to remove support for that configuration entirely. i’ll need this for the docs i’m working on to make sense.

$ git restore -Ws bccb2158fa8eae0c4939971b3fee6f58255bbcac actions
$ cp -R actions/runner-select actions/runner-select-queueless
$ git restore -W actions