### PR TITLE
image-deps: bump Ubuntu + Visual Studio + GitHub Actions runner

### DIFF
--- a/server/nixos/image-deps.nix
+++ b/server/nixos/image-deps.nix
@@ -21,8 +21,8 @@ in linkFarm "image-deps" {
     hash = "sha256-5LH57GE4YSMiR+DLY2HJuxqGUl1ijs1Ln+rcnvngwig=";
   };
   "macos13/actions-runner-osx-x64.tar.gz" = fetchurl {
-    url = "https://github.com/actions/runner/releases/download/v2.328.0/actions-runner-osx-x64-2.328.0.tar.gz";
-    hash = "sha256-kMMtxvKShVM5VjFI84WdxdQC8jfs31cBDIQd88jRLMg=";
+    url = "https://github.com/actions/runner/releases/download/v2.330.0/actions-runner-osx-x64-2.330.0.tar.gz";
+    hash = "sha256-QKMre4fiW3a1leIB4K83b8scO3g4/iFFKQl1YJBHPqk=";
   };
   "macos13/uv-installer.sh" = fetchurl {
     url = "https://github.com/astral-sh/uv/releases/download/0.8.17/uv-installer.sh";
@@ -45,8 +45,8 @@ in linkFarm "image-deps" {
     hash = "sha256-ozOfsATD0LuYYroLzgAYYf5cvenBDRZZHrPznubNPn8=";
   };
   "ubuntu2204/actions-runner-linux-x64.tar.gz" = fetchurl {
-    url = "https://github.com/actions/runner/releases/download/v2.328.0/actions-runner-linux-x64-2.328.0.tar.gz";
-    hash = "sha256-AQZvrTook+Y+bKiArjofrVv5Mp1g537hXyuXwUjDzU4=";
+    url = "https://github.com/actions/runner/releases/download/v2.330.0/actions-runner-linux-x64-2.330.0.tar.gz";
+    hash = "sha256-r1wz+pTzzDO46Xk3k5E2prBBl+ba38+ztuM64b9B55o=";
   };
   "ubuntu2204/uv-installer.sh" = fetchurl {
     url = "https://github.com/astral-sh/uv/releases/download/0.8.17/uv-installer.sh";
@@ -89,8 +89,8 @@ in linkFarm "image-deps" {
     hash = "sha256-e4MDmhuTBbDFDyOy4vAzGbjXhZsoEG5JuoLAbYEonfY=";
   };
   "windows10/actions-runner-win-x64.zip" = fetchurl {
-    url = "https://github.com/actions/runner/releases/download/v2.328.0/actions-runner-win-x64-2.328.0.zip";
-    hash = "sha256-pzrhkriyt4Lh2QwIkjAwkwsLlu05T+VkE6BzzG9pSHc=";
+    url = "https://github.com/actions/runner/releases/download/v2.330.0/actions-runner-win-x64-2.330.0.zip";
+    hash = "sha256-p0aefylJZXMn/ddWiP2IWOE1IgKEfQJNaLk94DOZB3k=";
   };
   "windows10/Git-2.45.1-64-bit.exe" = fetchurl {
     url = "https://github.com/git-for-windows/git/releases/download/v2.45.1.windows.1/Git-2.45.1-64-bit.exe";


### PR DESCRIPTION
this patch updates three of our image deps:
- Ubuntu images eventually get deleted from the cloud-images server
- Visual Studio installer constantly changes hash at the same URL
- GitHub Actions runner needs to stay up to date to avoid getting rejected