### PR TITLE
monitor / queue: handle requests for multiple runners

### DIFF
--- a/monitor/src/lib.rs
+++ b/monitor/src/lib.rs
@@ -13,7 +13,7 @@ pub fn validate_tokenless_select(
     unique_id: &str,
     qualified_repo: &str,
     run_id: &str,
-) -> rocket_eyre::Result<String> {
+) -> rocket_eyre::Result<(String, usize)> {
     if !qualified_repo.starts_with(&TOML.allowed_qualified_repo_prefix) {
         Err(EyreReport::InternalServerError(eyre!(
             "Not allowed on this `qualified_repo`"
@@ -62,5 +62,9 @@ pub fn validate_tokenless_select(
             "Wrong run_id in artifact"
         )))?
     };
-    Ok(profile_key.to_owned())
+    let runner_count = args
+        .remove("self_hosted_runner_count")
+        .unwrap_or("1")
+        .parse::<usize>()?;
+    Ok((profile_key.to_owned(), runner_count))
 }

--- a/monitor/src/main.rs
+++ b/monitor/src/main.rs
@@ -243,7 +243,8 @@ fn select_runner_route(
             "Tokenless select is disabled due to `queue_member` setting"
         )))?;
     }
-    let profile_key = validate_tokenless_select(&unique_id, &qualified_repo, &run_id)?;
+    let (profile_key, runner_count) =
+        validate_tokenless_select(&unique_id, &qualified_repo, &run_id)?;
     let (response_tx, response_rx) = crossbeam_channel::bounded(0);
     REQUEST.sender.send_timeout(
         Request::TakeRunners {
@@ -254,7 +255,7 @@ fn select_runner_route(
                 qualified_repo,
                 run_id,
             },
-            count: 1,
+            count: runner_count,
         },
         TOML.monitor_thread_send_timeout(),
     )?;


### PR DESCRIPTION
this patch adds support for requesting a cluster of multiple runners to the queue service (both tokenless and tokenful), and to the tokenless runner select endpoint in the monitor service. the tokenful endpoint in the monitor service already supported this, as part of earlier work towards running WPT on self-hosted runners (#21).

when you request multiple runners, the queue service will make you wait until that many runners are idle across all available servers, then it will reserve all of the requested runners at once. this is a bit inefficient, but it avoids complications where one runner might time out due to being reserved long before the others.

to request multiple runners for a tokenless job, add a line that reads `self_hosted_runner_count=2` (or more) to your runner select artifact (see #69 for more details).

to request multiple runners for a tokenful job in the queue service, use the new **POST /profile/&lt;profile_key>/enqueue/&lt;runner_count>?&lt;unique_id>&amp;&lt;qualified_repo>&amp;&lt;run_id>** endpoint.

to request multiple runners for a tokenful job in the monitor service, use the existing **POST /profile/&lt;profile_key>/take/&lt;count>?&lt;unique_id>&amp;&lt;qualified_repo>&amp;&lt;run_id>** endpoint.

test runs: <https://github.com/servo/ci-runners/issues/21#issuecomment-3611745859>