### PR TITLE
actions: handle requests for multiple runners

### DIFF
--- a/actions/runner-select/action.yml
+++ b/actions/runner-select/action.yml
@@ -9,6 +9,10 @@ inputs:
   self-hosted-image-name:
     required: true
     type: string
+  self-hosted-runner-count:
+    required: false
+    type: number
+    default: 1
   force-github-hosted-runner:
     required: false
     type: boolean
@@ -38,6 +42,7 @@ runs:
       run: |
         github_hosted_runner_label='${{ inputs.github-hosted-runner-label }}'
         self_hosted_image_name='${{ inputs.self-hosted-image-name }}'
+        self_hosted_runner_count='${{ inputs.self-hosted-runner-count }}'
 
         set -euo pipefail
 
@@ -72,6 +77,7 @@ runs:
 
         echo "unique_id=$unique_id" | tee -a "$artifact_path"
         echo "self_hosted_image_name=$self_hosted_image_name" | tee -a "$artifact_path"
+        echo "self_hosted_runner_count=$self_hosted_runner_count" | tee -a "$artifact_path"
         echo "qualified_repo=${{ github.repository }}" | tee -a "$artifact_path"
         echo "run_id=${{ github.run_id }}" | tee -a "$artifact_path"
 
@@ -130,7 +136,7 @@ runs:
         echo POST "$take_url"
         # Retry for up to 3600 seconds, nominally once per second for up to 3600 times,
         # but actually respecting Retry-After for up to 3600 times.
-        if curl -sS --fail-with-body --retry-max-time 3600 --retry 3600 --retry-delay 1 -X POST "$take_url_with_token" > $result \
+        if curl -sS --fail-with-body --connect-timeout 5 --max-time 30 --retry-max-time 3600 --retry 3600 --retry-delay 1 -X POST "$take_url_with_token" > $result \
             && jq -e . $result > /dev/null; then
           echo
           echo "selected_runner_label=reserved-for:$unique_id" | tee -a $GITHUB_OUTPUT


### PR DESCRIPTION
this patch is the actions side of #91, allowing runner-select to handle requests for multiple runners:

- the new input `self-hosted-runner-count` (default 1) controls how many runners to request
- we now set connect and total timeouts on the take request, which was previously overlooked

this is simple, but not quite enough to enable us to run WPT on self-hosted runners. see the next patch!

test runs: <https://github.com/servo/ci-runners/issues/21#issuecomment-3611745859>