### PR TITLE
actions: allow runner-select to generate runner indices

### DIFF
--- a/actions/runner-select/action.yml
+++ b/actions/runner-select/action.yml
@@ -17,10 +17,6 @@ inputs:
     required: false
     type: number
     default: 1
-  first-runner-index:
-    required: false
-    type: number
-    default: 0
   force-github-hosted-runner:
     required: false
     type: boolean
@@ -110,21 +106,18 @@ runs:
         github_hosted_runner_count='${{ inputs.github-hosted-runner-count }}'
         self_hosted_image_name='${{ inputs.self-hosted-image-name }}'
         self_hosted_runner_count='${{ inputs.self-hosted-runner-count }}'
-        first_runner_index='${{ inputs.first-runner-index }}'
         disabled='${{ steps.init.outputs.disabled }}'
         unique_id='${{ steps.init.outputs.unique_id }}'
 
         set -euo pipefail
 
         print_indices_array() {
-          runner_index=$first_runner_index
-          i=0; while [ $i -lt $1 ]; do
-            if [ $i -eq 0 ]; then
-              printf '[%s' $runner_index
+          i=1; while [ $i -le $1 ]; do
+            if [ $i -eq 1 ]; then
+              printf '[%s' $i
             else
-              printf ',%s' $runner_index
+              printf ',%s' $i
             fi
-            runner_index=$((runner_index + 1))
             i=$((i + 1))
           done
           printf ']'


### PR DESCRIPTION
this patch builds on #92, adding some supporting features to runner-select that will allow us to eliminate the “generate chunks” job in our WPT workflow:

- the new input `github-hosted-runner-count` (default 1) and the new output `selected-runner-count` allow the action to switch between two different runner counts for GitHub-hosted and self-hosted cases
- the new input `first-runner-index` (default 0) and the new output `selected-runner-indices` allow the action to generate a JSON array of runner indices or chunk ids as required by the WPT runner

if we landed #92 only, the WPT workflow would still need to run a job to generate chunk ids *between* runner-select and the workload (it would `needs` runner-select, and the workload would `needs` both). this is dangerous because that job may get delayed due to lack of GitHub-hosted runner capacity. if it gets delayed, the reservation may time out, and the workflow run will get stuck waiting forever for runners that will never come back.

test runs: <https://github.com/servo/ci-runners/issues/21#issuecomment-3611745859>