### PR TITLE
OHOS: Update command line tools version

### DIFF
--- a/docker/hos_commandline_tools/Dockerfile
+++ b/docker/hos_commandline_tools/Dockerfile
@@ -1,6 +1,6 @@
 FROM servo_gha_base:latest
 
 RUN mkdir -p data
-ARG COMMANDLINE_TOOLS_PATH=https://repo.huaweicloud.com/harmonyos/ohpm/5.0.5/commandline-tools-linux-x64-5.0.5.310.zip
+ARG COMMANDLINE_TOOLS_PATH=https://repo.huaweicloud.com/harmonyos/ohpm/5.1.0/commandline-tools-linux-x64-5.1.0.840.zip
 ADD ${COMMANDLINE_TOOLS_PATH} /data/commandline-tools.zip
 RUN cd data && unzip -q commandline-tools.zip


### PR DESCRIPTION
The command line tools currently in the repo do not work anymore with the current version of servo.
This updates it to the current public available one 5.1.0.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
