### PR TITLE
OHOS: update runner image

### DIFF
--- a/docker/runner/Dockerfile
+++ b/docker/runner/Dockerfile
@@ -1,7 +1,7 @@
 ARG GITHUB_ACTIONS_RUNNER_VERSION
 ARG HOS_COMMANDLINE_TOOLS_VERSION
 
-FROM ubuntu:20.04 AS rust
+FROM ubuntu:22.04 AS rust
 RUN apt update && apt install -y curl build-essential
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --default-toolchain stable \


### PR DESCRIPTION
Our base image is Ubuntu 22.04 but runner seems to not have been updated. 
This updates it from Ubuntu 20.04 to Ubuntu 22.04 saving downloads in the build process.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
