### PR TITLE
OHOS: Do not run xargs docker stop if empty

### DIFF
--- a/docker/docker_jit_monitor/servo_ci.service
+++ b/docker/docker_jit_monitor/servo_ci.service
@@ -7,7 +7,7 @@ Environment="DOCKER_HOST=unix:///run/user/<USERID>/docker.sock"
 Environment="GITHUB_TOKEN=<INSERT YOUR TOKEN>"
 Environment="SERVO_CI_GITHUB_API_SCOPE=<YOUR API SCOPE, /repos/servo/servo>"
 ExecStart=/home/servo_ci/ci-runners/docker/docker_jit_monitor/target/release/docker_jit_monitor
-ExecStopPost=sh -c 'docker ps -q | xargs docker stop'
+ExecStopPost=sh -c 'docker ps -q | xargs -r docker stop'
 TimeoutStopSec=15min
 ProtectKernelModules=no
 RestrictSUIDSGID=yes


### PR DESCRIPTION
This modified the systemd service ExecPostStop to not do anything if there are no containers left to stop.
Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
