### PR TITLE
OHOS: Update baked hitrace version

### DIFF
--- a/docker/runner/Dockerfile
+++ b/docker/runner/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update && apt install -y curl build-essential
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable \
         --profile=minimal
-RUN /root/.cargo/bin/cargo install hitrace-bench --version 0.9.1
+RUN /root/.cargo/bin/cargo install hitrace-bench --version 0.11
 
 FROM hos_commandline_tools:${HOS_COMMANDLINE_TOOLS_VERSION} AS commandline_tools
 


### PR DESCRIPTION
Soon we will have hitrace-version 0.11 which we should bake in next time we regenerate the images.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
