### PR TITLE
OHOS: Update to ubuntu 24.04

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-	
+
 
 # syntax=docker/dockerfile:1
 # check=error=true
@@ -8,7 +8,7 @@
 # quickly as possible.
 # We already add a user in this image, so all other images inherit it.
 
-FROM ubuntu:22.04 AS base_fetcher
+FROM ubuntu:24.04 AS base_fetcher
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     && rm -rf /var/cache/apt/lists
 
 ARG USERNAME=servo_ci
-ARG USER_UID=1000
+ARG USER_UID=1010
 ARG USER_GID=${USER_UID}
 
 RUN groupadd --gid ${USER_GID} ${USERNAME} && \

--- a/docker/runner/Dockerfile
+++ b/docker/runner/Dockerfile
@@ -1,7 +1,7 @@
 ARG GITHUB_ACTIONS_RUNNER_VERSION
 ARG HOS_COMMANDLINE_TOOLS_VERSION
 
-FROM ubuntu:22.04 AS rust
+FROM ubuntu:24.04 AS rust
 RUN apt update && apt install -y curl build-essential
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable \


### PR DESCRIPTION
This updates the base images to ubuntu 24.04 with keeping in line with the other jobs on CI.
The new ubuntu image has a default `ubuntu` user with UID 1000, so we adjust our UID.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
