### PR TITLE
ohos monitor: Allow configuring spawned runner types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /monitor.toml
 
 /docker/docker_jit_monitor/target/
+.DS_Store
+/target

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -3,7 +3,7 @@
 set -eu
 
 SERVO_GIT_HASH=$(git ls-remote https://github.com/servo/servo.git --branches refs/heads/main | awk '{ print $1}')
-GITHUB_ACTIONS_RUNNER_VERSION="2.333.0"
+GITHUB_ACTIONS_RUNNER_VERSION="2.334.0"
 MITMPROXY_VERSION="12.2.1"
 RUST_VERSION="1.92.0"
 UV_VERSION="0.9.28"

--- a/docker/docker_jit_monitor/Cargo.toml
+++ b/docker/docker_jit_monitor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-clap = { version = "4.2", features = ["derive"] }
+clap = { version = "4.2", features = ["derive", "env"] }
 anyhow = "1"
 log = "0.4"
 env_logger = "0.11.4"

--- a/docker/docker_jit_monitor/src/main.rs
+++ b/docker/docker_jit_monitor/src/main.rs
@@ -8,7 +8,7 @@ use std::{
 use thiserror::Error;
 
 use anyhow::{anyhow, Context};
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use log::{error, info, warn};
 
 use crate::github_api::{get_idle_runners, spawn_runner};
@@ -41,6 +41,21 @@ struct Args {
         default_value_t = 1
     )]
     concurrent_builders: u8,
+    #[clap(
+        long,
+        value_enum,
+        default_value_t = SingleLabelMode::Default,
+        help = "Limit this monitor to builder runners, runner runners, or keep the default mixed mode"
+    )]
+    single_label_mode: SingleLabelMode,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+enum SingleLabelMode {
+    #[default]
+    Default,
+    Builder,
+    Runner,
 }
 
 struct RunnerConfig {
@@ -153,8 +168,7 @@ impl ContainerType {
     /// This iterator will go from Builder -> Runner and then stop.
     fn iter() -> ContainerTypeIterator {
         ContainerTypeIterator {
-            current: None,
-            finished: false,
+            remaining: vec![ContainerType::Runner, ContainerType::Builder],
         }
     }
 
@@ -167,27 +181,33 @@ impl ContainerType {
     }
 }
 
+impl SingleLabelMode {
+    fn container_types(self) -> ContainerTypeIterator {
+        match self {
+            SingleLabelMode::Default => ContainerType::iter(),
+            SingleLabelMode::Builder => ContainerTypeIterator::single(ContainerType::Builder),
+            SingleLabelMode::Runner => ContainerTypeIterator::single(ContainerType::Runner),
+        }
+    }
+}
+
 struct ContainerTypeIterator {
-    current: Option<ContainerType>,
-    finished: bool,
+    remaining: Vec<ContainerType>,
+}
+
+impl ContainerTypeIterator {
+    fn single(container_type: ContainerType) -> Self {
+        Self {
+            remaining: vec![container_type],
+        }
+    }
 }
 
 impl Iterator for ContainerTypeIterator {
     type Item = ContainerType;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.finished {
-            return None;
-        }
-        self.current = match self.current {
-            None => Some(ContainerType::Builder),
-            Some(ContainerType::Builder) => Some(ContainerType::Runner),
-            Some(ContainerType::Runner) => {
-                self.finished = true;
-                None
-            }
-        };
-        self.current.clone()
+        self.remaining.pop()
     }
 }
 
@@ -197,6 +217,18 @@ fn iter_test() {
     assert_eq!(it.next(), Some(ContainerType::Builder));
     assert_eq!(it.next(), Some(ContainerType::Runner));
     assert_eq!(it.next(), None);
+}
+
+#[test]
+fn single_label_mode_test() {
+    let default_types = SingleLabelMode::Default.container_types().collect::<Vec<_>>();
+    assert_eq!(default_types, vec![ContainerType::Builder, ContainerType::Runner]);
+
+    let builder_types = SingleLabelMode::Builder.container_types().collect::<Vec<_>>();
+    assert_eq!(builder_types, vec![ContainerType::Builder]);
+
+    let runner_types = SingleLabelMode::Runner.container_types().collect::<Vec<_>>();
+    assert_eq!(runner_types, vec![ContainerType::Runner]);
 }
 
 #[derive(Debug)]
@@ -234,7 +266,7 @@ fn main() -> anyhow::Result<()> {
 
     loop {
         let exiting = EXITING.load(Ordering::Relaxed);
-        for container_type in ContainerType::iter() {
+        for container_type in args.single_label_mode.container_types() {
             if running_containers
                 .iter()
                 .filter(|container| container.container_type == container_type)

--- a/docker/docker_jit_monitor/src/main.rs
+++ b/docker/docker_jit_monitor/src/main.rs
@@ -37,6 +37,7 @@ struct Args {
     #[clap(
         short,
         long,
+        env = "SERVO_OHOS_CI_CONCURRENT_BUILDERS",
         help = "Number of concurrent builder github runners on this machine",
         default_value_t = 1
     )]

--- a/docker/docker_jit_monitor/src/main.rs
+++ b/docker/docker_jit_monitor/src/main.rs
@@ -45,7 +45,7 @@ struct Args {
         long,
         value_enum,
         default_value_t = SingleTypeMode::Both,
-        help = "Limit this monitor to builder runners, runner runners, or run both"
+        help = "set if you want only one type of runner running"
     )]
     single_type_mode: SingleTypeMode,
 }

--- a/docker/docker_jit_monitor/src/main.rs
+++ b/docker/docker_jit_monitor/src/main.rs
@@ -44,8 +44,8 @@ struct Args {
     #[clap(
         long,
         value_enum,
-        default_value_t = SingleTypeMode::Default,
-        help = "Limit this monitor to builder runners, runner runners, or keep the default mixed mode"
+        default_value_t = SingleTypeMode::Both,
+        help = "Limit this monitor to builder runners, runner runners, or run both"
     )]
     single_type_mode: SingleTypeMode,
 }
@@ -53,7 +53,7 @@ struct Args {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
 enum SingleTypeMode {
     #[default]
-    Default,
+    Both,
     Builder,
     Runner,
 }
@@ -181,26 +181,22 @@ impl ContainerType {
     }
 }
 
-impl SingleTypeMode {
-    fn container_types(self) -> ContainerTypeIterator {
-        match self {
-            SingleTypeMode::Default => ContainerType::iter(),
-            SingleTypeMode::Builder => ContainerTypeIterator::single(ContainerType::Builder),
-            SingleTypeMode::Runner => ContainerTypeIterator::single(ContainerType::Runner),
+impl From<SingleTypeMode> for ContainerTypeIterator {
+    fn from(value: SingleTypeMode) -> Self {
+        match value {
+            SingleTypeMode::Both => ContainerType::iter(),
+            SingleTypeMode::Builder => ContainerTypeIterator {
+                remaining: vec![ContainerType::Builder],
+            },
+            SingleTypeMode::Runner => ContainerTypeIterator {
+                remaining: vec![ContainerType::Runner],
+            },
         }
     }
 }
 
 struct ContainerTypeIterator {
     remaining: Vec<ContainerType>,
-}
-
-impl ContainerTypeIterator {
-    fn single(container_type: ContainerType) -> Self {
-        Self {
-            remaining: vec![container_type],
-        }
-    }
 }
 
 impl Iterator for ContainerTypeIterator {
@@ -221,13 +217,16 @@ fn iter_test() {
 
 #[test]
 fn single_type_mode_test() {
-    let default_types = SingleTypeMode::Default.container_types().collect::<Vec<_>>();
-    assert_eq!(default_types, vec![ContainerType::Builder, ContainerType::Runner]);
+    let both_types = ContainerTypeIterator::from(SingleTypeMode::Both).collect::<Vec<_>>();
+    assert_eq!(
+        both_types,
+        vec![ContainerType::Builder, ContainerType::Runner]
+    );
 
-    let builder_types = SingleTypeMode::Builder.container_types().collect::<Vec<_>>();
+    let builder_types = ContainerTypeIterator::from(SingleTypeMode::Builder).collect::<Vec<_>>();
     assert_eq!(builder_types, vec![ContainerType::Builder]);
 
-    let runner_types = SingleTypeMode::Runner.container_types().collect::<Vec<_>>();
+    let runner_types = ContainerTypeIterator::from(SingleTypeMode::Runner).collect::<Vec<_>>();
     assert_eq!(runner_types, vec![ContainerType::Runner]);
 }
 
@@ -266,7 +265,7 @@ fn main() -> anyhow::Result<()> {
 
     loop {
         let exiting = EXITING.load(Ordering::Relaxed);
-        for container_type in args.single_type_mode.container_types() {
+        for container_type in ContainerTypeIterator::from(args.single_type_mode) {
             if running_containers
                 .iter()
                 .filter(|container| container.container_type == container_type)

--- a/docker/docker_jit_monitor/src/main.rs
+++ b/docker/docker_jit_monitor/src/main.rs
@@ -43,7 +43,7 @@ struct Args {
     concurrent_builders: u8,
     #[clap(
         long,
-        env = "MODE",
+        env = "SERVO_OHOS_CI_MONITOR_MODE",
         value_enum,
         default_value_t = Mode::Both,
         help = "set if you want only one type of runner running"

--- a/docker/docker_jit_monitor/src/main.rs
+++ b/docker/docker_jit_monitor/src/main.rs
@@ -165,13 +165,6 @@ enum ContainerType {
 }
 
 impl ContainerType {
-    /// This iterator will go from Builder -> Runner and then stop.
-    fn iter() -> ContainerTypeIterator {
-        ContainerTypeIterator {
-            remaining: vec![ContainerType::Runner, ContainerType::Builder],
-        }
-    }
-
     /// The number of concurrent instances we allow for this container type
     fn concurrent_number(&self, args: &Args) -> usize {
         match self {
@@ -184,7 +177,9 @@ impl ContainerType {
 impl From<SingleTypeMode> for ContainerTypeIterator {
     fn from(value: SingleTypeMode) -> Self {
         match value {
-            SingleTypeMode::Both => ContainerType::iter(),
+            SingleTypeMode::Both => ContainerTypeIterator {
+                remaining: vec![ContainerType::Builder, ContainerType::Runner],
+            },
             SingleTypeMode::Builder => ContainerTypeIterator {
                 remaining: vec![ContainerType::Builder],
             },
@@ -208,19 +203,11 @@ impl Iterator for ContainerTypeIterator {
 }
 
 #[test]
-fn iter_test() {
-    let mut it = ContainerType::iter();
-    assert_eq!(it.next(), Some(ContainerType::Builder));
-    assert_eq!(it.next(), Some(ContainerType::Runner));
-    assert_eq!(it.next(), None);
-}
-
-#[test]
 fn single_type_mode_test() {
     let both_types = ContainerTypeIterator::from(SingleTypeMode::Both).collect::<Vec<_>>();
     assert_eq!(
         both_types,
-        vec![ContainerType::Builder, ContainerType::Runner]
+        vec![ContainerType::Runner, ContainerType::Builder]
     );
 
     let builder_types = ContainerTypeIterator::from(SingleTypeMode::Builder).collect::<Vec<_>>();

--- a/docker/docker_jit_monitor/src/main.rs
+++ b/docker/docker_jit_monitor/src/main.rs
@@ -44,14 +44,14 @@ struct Args {
     #[clap(
         long,
         value_enum,
-        default_value_t = SingleLabelMode::Default,
+        default_value_t = SingleTypeMode::Default,
         help = "Limit this monitor to builder runners, runner runners, or keep the default mixed mode"
     )]
-    single_label_mode: SingleLabelMode,
+    single_type_mode: SingleTypeMode,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
-enum SingleLabelMode {
+enum SingleTypeMode {
     #[default]
     Default,
     Builder,
@@ -181,12 +181,12 @@ impl ContainerType {
     }
 }
 
-impl SingleLabelMode {
+impl SingleTypeMode {
     fn container_types(self) -> ContainerTypeIterator {
         match self {
-            SingleLabelMode::Default => ContainerType::iter(),
-            SingleLabelMode::Builder => ContainerTypeIterator::single(ContainerType::Builder),
-            SingleLabelMode::Runner => ContainerTypeIterator::single(ContainerType::Runner),
+            SingleTypeMode::Default => ContainerType::iter(),
+            SingleTypeMode::Builder => ContainerTypeIterator::single(ContainerType::Builder),
+            SingleTypeMode::Runner => ContainerTypeIterator::single(ContainerType::Runner),
         }
     }
 }
@@ -220,14 +220,14 @@ fn iter_test() {
 }
 
 #[test]
-fn single_label_mode_test() {
-    let default_types = SingleLabelMode::Default.container_types().collect::<Vec<_>>();
+fn single_type_mode_test() {
+    let default_types = SingleTypeMode::Default.container_types().collect::<Vec<_>>();
     assert_eq!(default_types, vec![ContainerType::Builder, ContainerType::Runner]);
 
-    let builder_types = SingleLabelMode::Builder.container_types().collect::<Vec<_>>();
+    let builder_types = SingleTypeMode::Builder.container_types().collect::<Vec<_>>();
     assert_eq!(builder_types, vec![ContainerType::Builder]);
 
-    let runner_types = SingleLabelMode::Runner.container_types().collect::<Vec<_>>();
+    let runner_types = SingleTypeMode::Runner.container_types().collect::<Vec<_>>();
     assert_eq!(runner_types, vec![ContainerType::Runner]);
 }
 
@@ -266,7 +266,7 @@ fn main() -> anyhow::Result<()> {
 
     loop {
         let exiting = EXITING.load(Ordering::Relaxed);
-        for container_type in args.single_label_mode.container_types() {
+        for container_type in args.single_type_mode.container_types() {
             if running_containers
                 .iter()
                 .filter(|container| container.container_type == container_type)

--- a/docker/docker_jit_monitor/src/main.rs
+++ b/docker/docker_jit_monitor/src/main.rs
@@ -43,15 +43,16 @@ struct Args {
     concurrent_builders: u8,
     #[clap(
         long,
+        env = "MODE",
         value_enum,
-        default_value_t = SingleTypeMode::Both,
+        default_value_t = Mode::Both,
         help = "set if you want only one type of runner running"
     )]
-    single_type_mode: SingleTypeMode,
+    mode: Mode,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
-enum SingleTypeMode {
+enum Mode {
     #[default]
     Both,
     Builder,
@@ -174,16 +175,16 @@ impl ContainerType {
     }
 }
 
-impl From<SingleTypeMode> for ContainerTypeIterator {
-    fn from(value: SingleTypeMode) -> Self {
+impl From<Mode> for ContainerTypeIterator {
+    fn from(value: Mode) -> Self {
         match value {
-            SingleTypeMode::Both => ContainerTypeIterator {
+            Mode::Both => ContainerTypeIterator {
                 remaining: vec![ContainerType::Builder, ContainerType::Runner],
             },
-            SingleTypeMode::Builder => ContainerTypeIterator {
+            Mode::Builder => ContainerTypeIterator {
                 remaining: vec![ContainerType::Builder],
             },
-            SingleTypeMode::Runner => ContainerTypeIterator {
+            Mode::Runner => ContainerTypeIterator {
                 remaining: vec![ContainerType::Runner],
             },
         }
@@ -204,16 +205,16 @@ impl Iterator for ContainerTypeIterator {
 
 #[test]
 fn single_type_mode_test() {
-    let both_types = ContainerTypeIterator::from(SingleTypeMode::Both).collect::<Vec<_>>();
+    let both_types = ContainerTypeIterator::from(Mode::Both).collect::<Vec<_>>();
     assert_eq!(
         both_types,
         vec![ContainerType::Runner, ContainerType::Builder]
     );
 
-    let builder_types = ContainerTypeIterator::from(SingleTypeMode::Builder).collect::<Vec<_>>();
+    let builder_types = ContainerTypeIterator::from(Mode::Builder).collect::<Vec<_>>();
     assert_eq!(builder_types, vec![ContainerType::Builder]);
 
-    let runner_types = ContainerTypeIterator::from(SingleTypeMode::Runner).collect::<Vec<_>>();
+    let runner_types = ContainerTypeIterator::from(Mode::Runner).collect::<Vec<_>>();
     assert_eq!(runner_types, vec![ContainerType::Runner]);
 }
 
@@ -252,7 +253,7 @@ fn main() -> anyhow::Result<()> {
 
     loop {
         let exiting = EXITING.load(Ordering::Relaxed);
-        for container_type in ContainerTypeIterator::from(args.single_type_mode) {
+        for container_type in ContainerTypeIterator::from(args.mode) {
             if running_containers
                 .iter()
                 .filter(|container| container.container_type == container_type)


### PR DESCRIPTION
This is to be able to host builder and runner separately by passing an argument 