### PR TITLE
Add `target/` in the root folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /monitor.toml
 
 /docker/docker_jit_monitor/target/
+.DS_Store
+/target


### PR DESCRIPTION
Git sees the redundant `target/` that my IDE keeps building. I could "fix" it by some local settings on my machine, but it might be helpful to have it in the .gitignore