### PR TITLE
Add optional SDK path arg to the build.sh

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,6 +5,18 @@ set -eu
 COMMANDLINE_TOOLS_PATH="https://repo.huaweicloud.com/harmonyos/ohpm/5.1.0/commandline-tools-linux-x64-5.1.0.840.zip"
 STAGED_COMMANDLINE_TOOLS_PATH=
 
+sdk_version() {
+    local sdk_path
+    sdk_path="${1##*/}"
+
+    if [[ "${sdk_path}" =~ commandline-tools-linux-x64-(.+)\.zip$ ]]
+    then
+        echo "${BASH_REMATCH[1]}"
+    else
+        echo "${sdk_path}"
+    fi
+}
+
 usage() {
     echo "Usage: $0 [--sdk-path PATH]"
 }
@@ -42,6 +54,13 @@ cleanup() {
 }
 
 trap cleanup EXIT
+
+if [[ -f "${COMMANDLINE_TOOLS_PATH}" ]]
+then
+    echo "Using SDK version $(sdk_version "${COMMANDLINE_TOOLS_PATH}") from local archive: ${COMMANDLINE_TOOLS_PATH}"
+else
+    echo "Using SDK version $(sdk_version "${COMMANDLINE_TOOLS_PATH}") from web"
+fi
 
 if [[ -f "${COMMANDLINE_TOOLS_PATH}" ]]
 then

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,6 +2,54 @@
 
 set -eu
 
+COMMANDLINE_TOOLS_PATH="https://repo.huaweicloud.com/harmonyos/ohpm/5.1.0/commandline-tools-linux-x64-5.1.0.840.zip"
+STAGED_COMMANDLINE_TOOLS_PATH=
+
+usage() {
+    echo "Usage: $0 [--sdk-path PATH]"
+}
+
+while [[ "$#" -gt 0 ]]
+do
+    case "$1" in
+        --sdk-path)
+            if [[ "$#" -lt 2 ]]
+            then
+                echo "Missing value for --sdk-path" >&2
+                usage >&2
+                exit 1
+            fi
+            COMMANDLINE_TOOLS_PATH="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+cleanup() {
+    if [[ -n "${STAGED_COMMANDLINE_TOOLS_PATH}" && -f "${STAGED_COMMANDLINE_TOOLS_PATH}" ]]
+    then
+        rm -f "${STAGED_COMMANDLINE_TOOLS_PATH}"
+    fi
+}
+
+trap cleanup EXIT
+
+if [[ -f "${COMMANDLINE_TOOLS_PATH}" ]]
+then
+    STAGED_COMMANDLINE_TOOLS_PATH="hos_commandline_tools/.commandline-tools.zip"
+    cp "${COMMANDLINE_TOOLS_PATH}" "${STAGED_COMMANDLINE_TOOLS_PATH}"
+    COMMANDLINE_TOOLS_PATH=".commandline-tools.zip"
+fi
+
 SERVO_GIT_HASH=$(git ls-remote https://github.com/servo/servo.git --branches refs/heads/main | awk '{ print $1}')
 GITHUB_ACTIONS_RUNNER_VERSION="2.334.0"
 MITMPROXY_VERSION="12.2.1"
@@ -22,7 +70,8 @@ docker build gh_runner -f gh_runner/Dockerfile -t "servo_gha_runner:${GITHUB_ACT
     --build-arg=USERNAME=${IMAGE_USERNAME} \
     --build-arg=GITHUB_ACTIONS_RUNNER_VERSION=${GITHUB_ACTIONS_RUNNER_VERSION}
 docker build hos_commandline_tools -f hos_commandline_tools/Dockerfile -t "hos_commandline_tools" \
-   --build-arg=USERNAME=${IMAGE_USERNAME}
+   --build-arg=USERNAME=${IMAGE_USERNAME} \
+   "--build-arg=COMMANDLINE_TOOLS_PATH=${COMMANDLINE_TOOLS_PATH}"
 
 # Build the actual images
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,6 +4,7 @@ set -eu
 
 COMMANDLINE_TOOLS_PATH="https://repo.huaweicloud.com/harmonyos/ohpm/5.1.0/commandline-tools-linux-x64-5.1.0.840.zip"
 STAGED_COMMANDLINE_TOOLS_PATH=
+USER_SPECIFIED_SDK_PATH=0
 
 sdk_version() {
     local sdk_path
@@ -32,6 +33,7 @@ do
                 exit 1
             fi
             COMMANDLINE_TOOLS_PATH="$2"
+            USER_SPECIFIED_SDK_PATH=1
             shift 2
             ;;
         -h|--help)
@@ -45,6 +47,12 @@ do
             ;;
     esac
 done
+
+if [[ "${USER_SPECIFIED_SDK_PATH}" -eq 1 && "${COMMANDLINE_TOOLS_PATH}" != http://* && "${COMMANDLINE_TOOLS_PATH}" != https://* && ! -f "${COMMANDLINE_TOOLS_PATH}" ]]
+then
+    echo "SDK archive not found: ${COMMANDLINE_TOOLS_PATH}" >&2
+    exit 1
+fi
 
 cleanup() {
     if [[ -n "${STAGED_COMMANDLINE_TOOLS_PATH}" && -f "${STAGED_COMMANDLINE_TOOLS_PATH}" ]]


### PR DESCRIPTION
When building the local images using podman, it failes to download the SDK due to 403 error (does not happen on docker for some reason). 

So I added an optional arg to the `build.sh`, so that the build script could use locally pre-downloaded SDK of any version for image building. 

It also supports `-h/--help` just in case