### PR TITLE
server: improve `do run`, add `do mosh`, add `do restart-queue`

### DIFF
--- a/server/nixos/do
+++ b/server/nixos/do
@@ -45,8 +45,12 @@ case "$action" in
         esac
     done
     for host in $hosts; do
-        mosh root@"$host".servo.org -- "$@"
+        ssh root@"$host".servo.org -- "$@"
     done
+    ;;
+(mosh)
+    host=$1; shift
+    mosh root@"$host".servo.org -- "$@"
     ;;
 (logs)
     mosh root@"$1".servo.org tmux new 'journalctl -af'
@@ -55,7 +59,7 @@ case "$action" in
     mosh root@"$1".servo.org tmux new 'htop'
     ;;
 (*)
-    >&2 echo 'usage: ./do <deploy|read|write|restart-monitor|run|logs|htop> [args ...]'
+    >&2 echo 'usage: ./do <deploy|read|write|restart-monitor|run|mosh|logs|htop> [args ...]'
     exit 1
     ;;
 esac

--- a/server/nixos/do
+++ b/server/nixos/do
@@ -30,6 +30,14 @@ case "$action" in
         printf '>>> %s\n' https://"$host".servo.org
     done
     ;;
+(restart-queue)
+    for host; do
+        ssh root@"$host".servo.org systemctl restart queue
+    done
+    for host; do
+        printf '>>> %s\n' https://"$host".servo.org/queue/
+    done
+    ;;
 (run)
     hosts=
     for arg; do
@@ -59,7 +67,7 @@ case "$action" in
     mosh root@"$1".servo.org tmux new 'htop'
     ;;
 (*)
-    >&2 echo 'usage: ./do <deploy|read|write|restart-monitor|run|mosh|logs|htop> [args ...]'
+    >&2 echo 'usage: ./do <deploy|read|write|restart-monitor|restart-queue|run|mosh|logs|htop> [args ...]'
     exit 1
     ;;
 esac


### PR DESCRIPTION
`do run` used to run the given command with mosh instead of ssh, but this is annoying for bulk maintenance tasks, because mosh takes over the whole screen, has no scrollback, and the output disappears when complete. this patch adds `do mosh` that runs mosh for one server, and makes `do run` just use ssh. for example, some typical commands:

```
$ cd server/nixos
$ ./do run ci{0..4} -- rm -v /config/monitor/data/profiles/\*/snapshot
$ ./do mosh ci0 tmux new journalctl -afu monitor
```

`do restart-monitor` restarts monitor.service, but when reconfiguring the queue or updating the GitHub API token, we also need to restart queue.service. this patch adds a `do restart-queue` command for use in those situations. for example, to update the GitHub API token, edit `server/nixos/*/.env` and then run the following:

```
$ cd server/nixos
$ ./do restart-monitor ci{0..4}
$ ./do restart-queue ci0
```