### PR TITLE
profiles: deploy 3x ubuntu2204 and 0x ubuntu2204-wpt on ci{0..2}

### DIFF
--- a/server/nixos/ci0/monitor.toml
+++ b/server/nixos/ci0/monitor.toml
@@ -70,13 +70,13 @@ requires_normal_memory = "1G"  # Arbitrary non-zero guess
 [profiles.servo-ubuntu2204]
 profile_name = "servo-ubuntu2204"
 github_runner_label = "self-hosted-image:servo-ubuntu2204"
-target_count = 1
+target_count = 3
 requires_1g_hugepages = 24
 requires_normal_memory = "1G"  # Arbitrary non-zero guess
 
 [profiles.servo-ubuntu2204-wpt]
 profile_name = "servo-ubuntu2204-wpt"
 github_runner_label = "self-hosted-image:servo-ubuntu2204-wpt"
-target_count = 1
+target_count = 0
 requires_1g_hugepages = 48
 requires_normal_memory = "1G"  # Arbitrary non-zero guess

--- a/server/nixos/ci1/monitor.toml
+++ b/server/nixos/ci1/monitor.toml
@@ -70,13 +70,13 @@ requires_normal_memory = "1G"  # Arbitrary non-zero guess
 [profiles.servo-ubuntu2204]
 profile_name = "servo-ubuntu2204"
 github_runner_label = "self-hosted-image:servo-ubuntu2204"
-target_count = 1
+target_count = 3
 requires_1g_hugepages = 24
 requires_normal_memory = "1G"  # Arbitrary non-zero guess
 
 [profiles.servo-ubuntu2204-wpt]
 profile_name = "servo-ubuntu2204-wpt"
 github_runner_label = "self-hosted-image:servo-ubuntu2204-wpt"
-target_count = 1
+target_count = 0
 requires_1g_hugepages = 48
 requires_normal_memory = "1G"  # Arbitrary non-zero guess

--- a/server/nixos/ci2/monitor.toml
+++ b/server/nixos/ci2/monitor.toml
@@ -70,13 +70,13 @@ requires_normal_memory = "1G"  # Arbitrary non-zero guess
 [profiles.servo-ubuntu2204]
 profile_name = "servo-ubuntu2204"
 github_runner_label = "self-hosted-image:servo-ubuntu2204"
-target_count = 1
+target_count = 3
 requires_1g_hugepages = 24
 requires_normal_memory = "1G"  # Arbitrary non-zero guess
 
 [profiles.servo-ubuntu2204-wpt]
 profile_name = "servo-ubuntu2204-wpt"
 github_runner_label = "self-hosted-image:servo-ubuntu2204-wpt"
-target_count = 1
+target_count = 0
 requires_1g_hugepages = 48
 requires_normal_memory = "1G"  # Arbitrary non-zero guess


### PR DESCRIPTION
the work towards WPT on self-hosted runners has been shelved for now. this patch replaces three big WPT runners that none of our builds use, with six more servo-ubuntu2204 runners, for a total of nine of those runners.