### PR TITLE
ohos: Update Rust version and cargo profile

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,7 +5,7 @@ set -eu
 SERVO_GIT_HASH=$(git ls-remote https://github.com/servo/servo.git --branches refs/heads/main | awk '{ print $1}')
 GITHUB_ACTIONS_RUNNER_VERSION="2.334.0"
 MITMPROXY_VERSION="12.2.1"
-RUST_VERSION="1.92.0"
+RUST_VERSION="1.95.0"
 UV_VERSION="0.9.28"
 IMAGE_USERNAME=servo_ci
 

--- a/docker/hos_builder/Dockerfile
+++ b/docker/hos_builder/Dockerfile
@@ -112,4 +112,4 @@ RUN cd /data/servo/servo && ./mach bootstrap --skip-platform
 
 FROM servo_base AS servo_cooked_ohos_release
 
-RUN ./mach build --ohos --profile=release --no-package --no-default-features --features=tracing,tracing-hitrace
+RUN ./mach build --ohos --profile=checked-release --no-package --no-default-features --features=tracing,tracing-hitrace


### PR DESCRIPTION
Part of https://github.com/servo/ci-runners/issues/132 - fixes it for the ohos build.