### PR TITLE
profiles: bake in builds with `--profile checked-release`

### DIFF
--- a/profiles/servo-macos13/boot-script
+++ b/profiles/servo-macos13/boot-script
@@ -25,12 +25,11 @@ bake_servo_repo() (
     rustup show active-toolchain || rustup toolchain install
 
     ./mach bootstrap --force
+    # TODO: bake in a build for the libservo/MSRV job
     # Build the same way as a typical macOS libservo job, to allow for incremental builds.
-    # FIXME: `cargo build -p libservo` is busted on most platforms <https://github.com/servo/servo/issues/37939>
-    # FIXME: `cargo build -p libservo` is untested in CI <https://github.com/servo/servo/issues/38015>
-    # cargo build -p libservo --all-targets --release --target-dir target/libservo
+    # cargo build -p libservo --all-targets --profile checked-release --target-dir target/libservo
     # Build the same way as a typical macOS build job, to allow for incremental builds.
-    ./mach build --use-crown --locked --release
+    ./mach build --use-crown --locked --profile checked-release
 )
 
 start_github_actions_runner() {

--- a/profiles/servo-macos14/boot-script
+++ b/profiles/servo-macos14/boot-script
@@ -27,9 +27,9 @@ bake_servo_repo() (
     ./mach bootstrap --force
     # TODO: bake in a build for the libservo/MSRV job
     # Build the same way as a typical macOS libservo job, to allow for incremental builds.
-    # cargo build -p libservo --all-targets --profile release --target-dir target/libservo
+    # cargo build -p libservo --all-targets --profile checked-release --target-dir target/libservo
     # Build the same way as a typical macOS build job, to allow for incremental builds.
-    ./mach build --use-crown --locked --profile release
+    ./mach build --use-crown --locked --profile checked-release
 )
 
 start_github_actions_runner() {

--- a/profiles/servo-macos14/boot-script
+++ b/profiles/servo-macos14/boot-script
@@ -25,12 +25,11 @@ bake_servo_repo() (
     rustup show active-toolchain || rustup toolchain install
 
     ./mach bootstrap --force
+    # TODO: bake in a build for the libservo/MSRV job
     # Build the same way as a typical macOS libservo job, to allow for incremental builds.
-    # FIXME: `cargo build -p libservo` is busted on most platforms <https://github.com/servo/servo/issues/37939>
-    # FIXME: `cargo build -p libservo` is untested in CI <https://github.com/servo/servo/issues/38015>
-    # cargo build -p libservo --all-targets --release --target-dir target/libservo
+    # cargo build -p libservo --all-targets --profile release --target-dir target/libservo
     # Build the same way as a typical macOS build job, to allow for incremental builds.
-    ./mach build --use-crown --locked --release
+    ./mach build --use-crown --locked --profile release
 )
 
 start_github_actions_runner() {

--- a/profiles/servo-macos15/boot-script
+++ b/profiles/servo-macos15/boot-script
@@ -25,12 +25,11 @@ bake_servo_repo() (
     rustup show active-toolchain || rustup toolchain install
 
     ./mach bootstrap --force
+    # TODO: bake in a build for the libservo/MSRV job
     # Build the same way as a typical macOS libservo job, to allow for incremental builds.
-    # FIXME: `cargo build -p libservo` is busted on most platforms <https://github.com/servo/servo/issues/37939>
-    # FIXME: `cargo build -p libservo` is untested in CI <https://github.com/servo/servo/issues/38015>
-    # cargo build -p libservo --all-targets --release --target-dir target/libservo
+    # cargo build -p libservo --all-targets --profile checked-release --target-dir target/libservo
     # Build the same way as a typical macOS build job, to allow for incremental builds.
-    ./mach build --use-crown --locked --release
+    ./mach build --use-crown --locked --profile checked-release
 )
 
 start_github_actions_runner() {

--- a/profiles/servo-ubuntu2204/boot-script
+++ b/profiles/servo-ubuntu2204/boot-script
@@ -27,14 +27,14 @@ bake_servo_repo() (
 
     # DEBIAN_FRONTEND needed to avoid hang when installing tshark
     DEBIAN_FRONTEND=noninteractive ./mach bootstrap --force
+    # TODO: bake in a build for the libservo/MSRV job
     # Build the same way as a typical Linux libservo job, to allow for incremental builds.
-    # FIXME: `cargo build -p libservo` is untested in CI <https://github.com/servo/servo/issues/38015>
-    # cargo build -p libservo --all-targets --release --target-dir target/libservo
+    # cargo build -p libservo --all-targets --profile checked-release --target-dir target/libservo
     # Build the same way as a typical Linux build job, to allow for incremental builds.
-    ./mach build --use-crown --locked --release
+    ./mach build --use-crown --locked --profile checked-release
     # Some hacks that seem to help with incremental builds.
     git status
-    ./mach build --use-crown --locked --release
+    ./mach build --use-crown --locked --profile checked-release
 )
 
 install_github_actions_runner() {
@@ -54,7 +54,7 @@ reheat_servo_repo() (
     git status
 
     # Freshen cargo’s understanding of the incremental build.
-    ./mach build --use-crown --locked --release
+    ./mach build --use-crown --locked --profile checked-release
 )
 
 start_github_actions_runner() {

--- a/profiles/servo-windows10/boot-script
+++ b/profiles/servo-windows10/boot-script
@@ -128,12 +128,11 @@ if (!(Test-Path .\image-built)) {
     echo "`$env:PATH in runner image = $env:PATH" >> C:\init\incremental_build_debug.txt
 
     $env:RUSTUP_WINDOWS_PATH_ADD_BIN = 1
+    # TODO: bake in a build for the libservo/MSRV job
     # Build the same way as a typical Windows libservo job, to allow for incremental builds.
-    # FIXME: `cargo build -p libservo` is busted on most platforms <https://github.com/servo/servo/issues/37939>
-    # FIXME: `cargo build -p libservo` is untested in CI <https://github.com/servo/servo/issues/38015>
-    # cargo build -p libservo --all-targets --release --target-dir target\libservo; Check
+    # cargo build -p libservo --all-targets --profile checked-release --target-dir target\libservo; Check
     # Build the same way as a typical Windows build job, to allow for incremental builds.
-    .\mach build --use-crown --locked --release; Check
+    .\mach build --use-crown --locked --profile checked-release; Check
 
     # Leave the Servo repo
     cd C:\ci


### PR DESCRIPTION
as of #44177, we now build servo in CI with `--profile checked-release`, so update the baked builds accordingly.

also remove references to libservo CI issues that have since been resolved.

Fixes: #132 