### PR TITLE
server: Raise `client_max_body_size` for intermittent-tracker

### DIFF
--- a/server/nixos/configuration.nix
+++ b/server/nixos/configuration.nix
@@ -169,11 +169,9 @@
     enable = true;
     # logError = "stderr notice";
     recommendedProxySettings = true;
-    commonHttpConfig = ''
-      # Raise client_max_body_size to avoid "HTTP Error 413: Request Entity Too Large."
-      # in intermittent-tracker (see #135, servo/servo#31845)
-      client_max_body_size 20m;
-    '';
+    # Raise client_max_body_size to avoid "HTTP Error 413: Request Entity Too Large."
+    # in intermittent-tracker (see #135, servo/servo#31845)
+    clientMaxBodySize = "20m";
     virtualHosts = let
       proxy = {
         extraConfig = ''

--- a/server/nixos/configuration.nix
+++ b/server/nixos/configuration.nix
@@ -203,11 +203,18 @@
       "intermittent-tracker.servo.org" = lib.mkIf hasIntermittentTracker ({
         locations."/" = proxy // {
           proxyPass = "http://127.0.0.1:5000";
+          extraConfig = ''
+            # Raise client_max_body_size to avoid "HTTP Error 413: Request Entity Too Large."
+            client_max_body_size 20m;
+          '';
         };
       } // ssl);
       "staging.intermittent-tracker.servo.org" = lib.mkIf hasIntermittentTracker ({
         locations."/" = proxy // {
           proxyPass = "http://127.0.0.1:5001";
+          extraConfig = ''
+            client_max_body_size 20m;
+          '';
         };
       } // ssl);
     };

--- a/server/nixos/configuration.nix
+++ b/server/nixos/configuration.nix
@@ -169,6 +169,11 @@
     enable = true;
     # logError = "stderr notice";
     recommendedProxySettings = true;
+    commonHttpConfig = ''
+      # Raise client_max_body_size to avoid "HTTP Error 413: Request Entity Too Large."
+      # in intermittent-tracker (see #135, servo/servo#31845)
+      client_max_body_size 20m;
+    '';
     virtualHosts = let
       proxy = {
         extraConfig = ''
@@ -203,18 +208,11 @@
       "intermittent-tracker.servo.org" = lib.mkIf hasIntermittentTracker ({
         locations."/" = proxy // {
           proxyPass = "http://127.0.0.1:5000";
-          extraConfig = ''
-            # Raise client_max_body_size to avoid "HTTP Error 413: Request Entity Too Large."
-            client_max_body_size 20m;
-          '';
         };
       } // ssl);
       "staging.intermittent-tracker.servo.org" = lib.mkIf hasIntermittentTracker ({
         locations."/" = proxy // {
           proxyPass = "http://127.0.0.1:5001";
-          extraConfig = ''
-            client_max_body_size 20m;
-          '';
         };
       } // ssl);
     };


### PR DESCRIPTION
WPT Import https://github.com/servo/servo/actions/runs/26348192526 is currently blocked because the intermittent-tracker server rejected queries to https://intermittent-tracker.servo.org/dashboard/query with "HTTP Error 413: Request Entity Too Large" when the request body is too large.

Attempt to unblock it by raising the `client_max_body_size` setting of nginx for intermittent-tracker servers to `20m`. (The default value of global `client_max_body_size` setting of nginx in NixOS is `10m`, instead of `1m` in standalone nginx.)

Remark: There was a discussion on similar issue, before migrating CI servers to NixOS. https://github.com/servo/servo/issues/31845