### PR TITLE
servo-windows10: fix prebaked servo check

### DIFF
--- a/profiles/servo-windows10/boot-script
+++ b/profiles/servo-windows10/boot-script
@@ -152,7 +152,7 @@ if (!(Test-Path .\image-built)) {
     # Check that servoshell was built.
     # This is janky, but we don’t really trust $LASTEXITCODE checks on Windows
     # as much as their counterpart on Unix
-    if ((Test-Path C:\a\servo\servo\target\release\servoshell.exe) -or (Test-Path C:\a\servo\servo\target\release\servo.exe)) {
+    if ((Test-Path C:\a\servo\servo\target\checked-release\servoshell.exe) -or (Test-Path C:\a\servo\servo\target\checked-release\servo.exe)) {
         New-Item C:\ci\image-built
         shutdown /s /t 0
         exit  # `shutdown` does not exit


### PR DESCRIPTION
#134 changed the prebaked servo from `release` to `checked-release`, but i forgot to update the janky build check in servo-windows10, so rebuilds for that image always fail. this patch fixes that.