### PR TITLE
ohos: Remove catch in sign script so that the error is propogated and not ignored

### DIFF
--- a/docker/runner/signing-util/sign.js
+++ b/docker/runner/signing-util/sign.js
@@ -9,15 +9,9 @@ const fs = require("fs");
 const path = require("path");
 class DecipherUtil {
   static decryptPwd(r, e) {
-    let t = buffer.Buffer.from("");
-    try {
-      const i = DecipherUtil.getKey(r),
-            o = new Int8Array(buffer.Buffer.from(e, "hex"));
-      t = DecipherUtil.decrypt(i, o)
-    } catch (e) {
-      console.log(e);
-    }
-    return t.toString("utf-8")
+    const i = DecipherUtil.getKey(r),
+          o = new Int8Array(buffer.Buffer.from(e, "hex"));
+    return DecipherUtil.decrypt(i, o).toString("utf-8")
   }
   static getKey(r) {
     const e = path.resolve(r, "material");


### PR DESCRIPTION
In the current state, when running
```bash
uv run main.py ~/path-to-build-profile.json5
```
from the `docker/runner/signing-util`, there is a case when it fails:

When the `build-profile.json5` is valid, but `material` dir is not present, the script will still print out "File sign.sh written" and the file will actually be written. But instead of expected contents, the file would have a `node error message` inside it. Because the python does 
```Python
return subprocess.check_output(["node", "sign.js", path, password])
```
but the JS:
```js
...
    } catch (e) {
      console.log(e);
    }
```

so the current PR just removes the catch, so that the error can propagate and now python returns full error message into the stdout and does not produce the `sign.sh`