### PR TITLE
ohos: Set sign.sh to be executable in the image

### DIFF
--- a/docker/runner/Dockerfile
+++ b/docker/runner/Dockerfile
@@ -41,7 +41,7 @@ RUN chown ${USERNAME}:${USERNAME} -R /home/${USERNAME}/.ohos
 # Used to authorize with the hdc device and avoid the confirmation dialog.
 COPY --chown=${USERNAME}:${USERNAME} hdckey hdckey.pub /home/${USERNAME}/.harmony/
 
-COPY sign.sh /usr/bin/sign-hos.sh
+COPY --chmod=755 sign.sh /usr/bin/sign-hos.sh
 
 ARG MITMPROXY_VERSION
 ARG UV_VERSION


### PR DESCRIPTION
Currently, depending on the host machine, when building with the `build.sh` the `uv run main.py` generated `sign.sh` file does not get permission to be executable by default, and on my machine, the permissions would also make it non executable in the image. So instead of manually doing +x on the `sign.sh` I propose adding chmod 755 to the dockerfile, so that the images gets correct permissions no matter the host settings