### PR TITLE
monitor: Configure systemd restart limits to better handle transient GH issues.

### DIFF
--- a/server/nixos/configuration.nix
+++ b/server/nixos/configuration.nix
@@ -310,6 +310,11 @@
       serviceConfig = {
         WorkingDirectory = "/config/monitor";
         Restart = "on-failure";
+        RestartSec = "5s";
+        RestartSteps = 5;
+        RestartMaxDelaySec = "5min";
+        StartLimitBurst = 10;
+        StartLimitIntervalSec = "35min";
       };
     };
 


### PR DESCRIPTION
This patch changes the default restart limits so that the monitor service doesn't get stuck in a failed state by restarting too quickly and exhausting systemd's default rate limits. The new configuration will attempt to restart the service with an [exponential backoff] rate of 2.27 and a maximum of 5 minutes i.e. the restarts will be attempted in the following sequence 5s, 11.3s, 26s, 58.5s, 2m 21s, 5m, 5m ...

We also set a maximum of 10 restarts in 35 minutes so we don't restart indefinetly. This can be relaxed later if we find that it still doesn't help with recovery from intermittent GH issues.

Potentially fixes: #112
Testing: Not tested. The code is based on my understanding of the systemd docs.

[exponential backoff]: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html?#RestartSteps=