### PR TITLE
Add `allow-unafe-pr-checkout` to the checkout action

### DIFF
--- a/actions/checkout/action.yml
+++ b/actions/checkout/action.yml
@@ -26,6 +26,9 @@ runs:
       with:
         ref: ${{ steps.choose-commit.outputs.commit }}
         fetch-depth: ${{ inputs.fetch-depth }}
+        # This is necessary to check out pull requests for `pull_request_target` actions,
+        # which are used for things like the WPT update job and the try label.
+        allow-unsafe-pr-checkout: true
 
     # Use prebaked repo on self-hosted runners
     - if: ${{ runner.environment == 'self-hosted' && inputs.fetch-depth != 0 }}


### PR DESCRIPTION
This was the default in older versions of the checkout action and we
need this in Servo for a couple (farly locked down workflows).
